### PR TITLE
Pull in K3s PRs from rancher docs

### DIFF
--- a/docs/installation/ha-embedded.md
+++ b/docs/installation/ha-embedded.md
@@ -22,7 +22,7 @@ After launching the first server, join the second and third servers to the clust
 K3S_TOKEN=SECRET k3s server --server https://<ip or hostname of server1>:6443
 ```
 
-Now you have a highly available control plane. Joining additional worker nodes to the cluster follows the same procedure as a single server cluster.
+Now you have a highly available control plane. Any successfully clustered servers can be used in the `--server` argument to join additional server and worker nodes. Joining additional worker nodes to the cluster follows the same procedure as a single server cluster.
 
 There are a few config flags that must be the same in all server nodes:         
 
@@ -33,4 +33,7 @@ There are a few config flags that must be the same in all server nodes:
 ## Existing clusters
 If you have an existing cluster using the default embedded SQLite database, you can convert it to etcd by simply restarting your K3s server with the `--cluster-init` flag. Once you've done that, you'll be able to add additional instances as described above.
 
+If an etcd datastore is found on disk either because that node has either initialized or joined a cluster already, the datastore arguments (`--cluster-init`, `--server`, `--datastore-endpoint`, etc) are ignored.
+
 >**Important:** K3s v1.22.2 and newer support migration from SQLite to etcd. Older versions will create a new empty datastore if you add `--cluster-init` to an existing server.
+

--- a/docs/installation/ha-embedded.md
+++ b/docs/installation/ha-embedded.md
@@ -10,6 +10,7 @@ Embedded etcd replaced experimental Dqlite in the K3s v1.19.1 release. This is a
 >**Warning:**
 Embedded etcd (HA) may have performance issues on slower disks such as Raspberry Pis running with SD cards.
 
+## New cluster
 To run K3s in this mode, you must have an odd number of server nodes. We recommend starting with three nodes.
 
 To get started, first launch a server node with the `cluster-init` flag to enable clustering and a token that will be used as a shared secret to join additional servers to the cluster.
@@ -19,7 +20,16 @@ curl -sfL https://get.k3s.io | K3S_TOKEN=SECRET sh -s - server --cluster-init
 
 After launching the first server, join the second and third servers to the cluster using the shared secret:
 ```bash
-K3S_TOKEN=SECRET k3s server --server https://<ip or hostname of server1>:6443
+curl -sfL https://get.k3s.io | K3S_TOKEN=SECRET sh -s - server --server https://<ip or hostname of server1>:6443
+```
+
+Check to see that the second and third servers are now part of the cluster:
+
+```bash
+$ kubectl get nodes
+NAME        STATUS   ROLES                       AGE   VERSION
+server1     Ready    control-plane,etcd,master   28m   vX.Y.Z
+server2     Ready    control-plane,etcd,master   13m   vX.Y.Z
 ```
 
 Now you have a highly available control plane. Any successfully clustered servers can be used in the `--server` argument to join additional server and worker nodes. Joining additional worker nodes to the cluster follows the same procedure as a single server cluster.

--- a/docs/installation/ha.md
+++ b/docs/installation/ha.md
@@ -31,7 +31,7 @@ Setting up an HA cluster requires the following steps:
 You will first need to create an external datastore for the cluster. See the [Cluster Datastore Options](/installation/datastore) documentation for more details.
 
 ### 2. Launch Server Nodes
-K3s requires two or more server nodes for this HA configuration. See the [Installation Requirements](/installation/requirements) guide for minimum machine requirements.
+K3s requires two or more server nodes for this HA configuration. See the [Requirements](/installation/requirements) guide for minimum machine requirements.
 
 When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore. The `token` parameter can also be used to set a deterministic token when adding nodes. When empty, this token will be generated automatically for further use.
 
@@ -48,7 +48,7 @@ The datastore endpoint format differs based on the database type. For details, r
 To configure TLS certificates when launching server nodes, refer to the [datastore configuration guide.](/installation/datastore#external-datastore-configuration-parameters)
 
 :::note
-The same installation options available to single-server installs are also available for high-availability installs. For more details, see the [Installation and Configuration Options](/installation/configuration) documentation.
+The same installation options available to single-server installs are also available for high-availability installs. For more details, see the [Configuration Options](/installation/configuration) documentation.
 :::
 
 By default, server nodes will be schedulable and thus your workloads can get launched on them. If you wish to have a dedicated control plane where no user workloads will run, you can use taints. The `node-taint` parameter will allow you to configure nodes with taints, for example `--node-taint CriticalAddonsOnly=true:NoExecute`.

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -3,9 +3,9 @@ title: "Installation"
 weight: 20
 ---
 
-This section contains instructions for installing K3s in various environments. Please ensure you have met the [Installation Requirements](/installation/requirements/) before you begin installing K3s.
+This section contains instructions for installing K3s in various environments. Please ensure you have met the [Requirements](/installation/requirements/) before you begin installing K3s.
 
-[Installation and Configuration Options](/installation/configuration/) provides guidance on the options available to you when installing K3s.
+[Configuration Options](/installation/configuration/) provides guidance on the options available to you when installing K3s.
 
 [High Availability with an External DB](/installation/ha/) details how to set up an HA K3s cluster backed by an external datastore such as MySQL, PostgreSQL, or etcd.
 

--- a/docs/installation/kube-dashboard.md
+++ b/docs/installation/kube-dashboard.md
@@ -3,6 +3,9 @@ title: "Kubernetes Dashboard"
 weight: 60
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 This installation guide will help you to deploy and configure the [Kubernetes Dashboard](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/) on K3s.
 
 ### Deploying the Kubernetes Dashboard
@@ -51,10 +54,22 @@ sudo k3s kubectl create -f dashboard.admin-user.yml -f dashboard.admin-user-role
 ```
 
 ### Obtain the Bearer Token
+<Tabs>
+<TabItem value="v1.24 and newer">
+
+```bash
+sudo k3s kubectl -n kubernetes-dashboard create token admin-user
+```
+</TabItem>
+<TabItem value="v1.23 and older">
 
 ```bash
 sudo k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep '^token'
 ```
+
+</TabItem>
+</Tabs>
+
 
 ### Local Access to the Dashboard
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -7,7 +7,7 @@ This page explains how CoreDNS, the Traefik Ingress controller, and Klipper serv
 
 Refer to the [Installation Network Options](/installation/network-options/) page for details on Flannel configuration options and backend selection, or how to set up your own CNI.
 
-For information on which ports need to be opened for K3s, refer to the [Installation Requirements.](/installation/requirements/#networking)
+For information on which ports need to be opened for K3s, refer to the [ Requirements.](/installation/requirements/#networking)
 
 - [CoreDNS](#coredns)
 - [Traefik Ingress Controller](#traefik-ingress-controller)


### PR DESCRIPTION
During the conversion to the K3s docs website, several K3s Docs PRs merged into the old Rancher Docs page. This pulls in:
https://github.com/rancher/docs/pull/4175
https://github.com/rancher/docs/pull/4181
https://github.com/rancher/docs/pull/4186