### PR TITLE
Fix to website baseUrl + Relative Internal Links

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -37,7 +37,7 @@ If the certificates are expired or have fewer than 90 days remaining before they
 
 Any file found in `/var/lib/rancher/k3s/server/manifests` will automatically be deployed to Kubernetes in a manner similar to `kubectl apply`, both on startup and when the file is changed on disk. Deleting files out of this directory will not delete the corresponding resources from the cluster.
 
-For information about deploying Helm charts, refer to the section about [Helm.](/docs/helm)
+For information about deploying Helm charts, refer to the section about [Helm.](helm/helm.md)
 
 ## Using Docker as the Container Runtime
 
@@ -202,7 +202,7 @@ See also https://rootlesscontaine.rs/ to learn about Rootless mode.
 
 ## Node Labels and Taints
 
-K3s agents can be configured with the options `--node-label` and `--node-taint` which adds a label and taint to the kubelet. The two options only add labels and/or taints [at registration time,](/docs/reference/agent-config#node-labels-and-taints-for-agents) so they can only be added once and not changed after that again by running K3s commands.
+K3s agents can be configured with the options `--node-label` and `--node-taint` which adds a label and taint to the kubelet. The two options only add labels and/or taints [at registration time,](reference/agent-config.md#node-labels-and-taints-for-agents) so they can only be added once and not changed after that again by running K3s commands.
 
 If you want to change node labels and taints after node registration you should use `kubectl`. Refer to the official Kubernetes documentation for details on how to add [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) and [node labels.](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#add-a-label-to-a-node)
 

--- a/docs/backup-restore/backup-restore.md
+++ b/docs/backup-restore/backup-restore.md
@@ -56,7 +56,7 @@ k3s server \
 
 #### Options
 
-These options can be passed in with the command line, or in the [configuration file,](/docs/installation/configuration/#configuration-file ) which may be easier to use.
+These options can be passed in with the command line, or in the [configuration file,](installation/configuration.md/#configuration-file ) which may be easier to use.
 
 | Options | Description |
 | ----------- | --------------- |

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -31,7 +31,7 @@ When running with systemd, logs will be created in `/var/log/syslog` and viewed 
 
 ### Can I run K3s in Docker?
 
-Yes, there are multiple ways to run K3s in Docker. See [Advanced Options](/docs/advanced#running-k3s-in-docker) for more details.
+Yes, there are multiple ways to run K3s in Docker. See [Advanced Options](advanced/advanced.md#running-k3s-in-docker) for more details.
 ### What is the difference between K3s Server and Agent Tokens?
 
 In K3s, there are two types of tokens: K3S_TOKEN and K3S_AGENT_TOKEN.

--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -5,7 +5,7 @@ weight: 42
 
 Helm is the package management tool of choice for Kubernetes. Helm charts provide templating syntax for Kubernetes YAML manifest documents. With Helm we can create configurable deployments instead of just using static files. For more information about creating your own catalog of deployments, check out the docs at [https://helm.sh/docs/intro/quickstart/](https://helm.sh/docs/intro/quickstart/).
 
-K3s does not require any special configuration to use with Helm command-line tools. Just be sure you have properly set up your kubeconfig as per the section about [cluster access](/docs/cluster-access). K3s does include some extra functionality to make deploying both traditional Kubernetes resource manifests and Helm Charts even easier with the [rancher/helm-release CRD.](#using-the-helm-crd)
+K3s does not require any special configuration to use with Helm command-line tools. Just be sure you have properly set up your kubeconfig as per the section about [cluster access](cluster-access/cluster-access.md). K3s does include some extra functionality to make deploying both traditional Kubernetes resource manifests and Helm Charts even easier with the [rancher/helm-release CRD.](#using-the-helm-crd)
 
 This section covers the following topics:
 
@@ -122,6 +122,6 @@ spec:
 
 > **Note:** K3s versions starting with v1.17.0+k3s.1 support Helm v3, and will use it by default. Helm v2 charts can be used by setting `helmVersion: v2` in the spec.
 
-If you were using Helm v2 in previous versions of K3s, you may upgrade to v1.17.0+k3s.1 or newer and Helm 2 will still function. If you wish to migrate to Helm 3, [this](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) blog post by Helm explains how to use a plugin to successfully migrate. Refer to the official Helm 3 documentation [here](https://helm.sh/docs/) for more information. K3s will handle either Helm v2 or Helm v3 as of v1.17.0+k3s.1. Just be sure you have properly set your kubeconfig as per the examples in the section about [cluster access.](/docs/cluster-access)
+If you were using Helm v2 in previous versions of K3s, you may upgrade to v1.17.0+k3s.1 or newer and Helm 2 will still function. If you wish to migrate to Helm 3, [this](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) blog post by Helm explains how to use a plugin to successfully migrate. Refer to the official Helm 3 documentation [here](https://helm.sh/docs/) for more information. K3s will handle either Helm v2 or Helm v3 as of v1.17.0+k3s.1. Just be sure you have properly set your kubeconfig as per the examples in the section about [cluster access.](cluster-access/cluster-access.md)
 
 Note that Helm 3 no longer requires Tiller and the `helm init` command. Refer to the official documentation for details.

--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -15,7 +15,7 @@ If you have not yet set up a private Docker registry, refer to the official docu
 
 ### Create the Registry YAML
 
-Follow the [Private Registry Configuration](/docs/installation/private-registry) guide to create and configure the registry.yaml file.
+Follow the [Private Registry Configuration](private-registry.md) guide to create and configure the registry.yaml file.
 
 Once you have completed this, you may now go to the [Install K3s](#install-k3s) section below.
 
@@ -72,7 +72,7 @@ INSTALL_K3S_SKIP_DOWNLOAD=true K3S_URL=https://myserver:6443 K3S_TOKEN=mynodetok
 </TabItem>
 <TabItem value="High Availability Configuration" default>
 
-Reference the [High Availability with an External DB](/docs/installation/ha) or [High Availability with Embedded DB](/docs/installation/ha-embedded) guides. You will be tweaking install commands so you specify `INSTALL_K3S_SKIP_DOWNLOAD=true` and run your install script locally instead of via curl. You will also utilize `INSTALL_K3S_EXEC='args'` to supply any arguments to k3s.
+Reference the [High Availability with an External DB](ha.md) or [High Availability with Embedded DB](ha.md-embedded) guides. You will be tweaking install commands so you specify `INSTALL_K3S_SKIP_DOWNLOAD=true` and run your install script locally instead of via curl. You will also utilize `INSTALL_K3S_EXEC='args'` to supply any arguments to k3s.
 
 For example, step two of the High Availability with an External DB guide mentions the following:
 
@@ -107,7 +107,7 @@ with the same environment variables.
 
 ### Automated Upgrades Method
 
-As of v1.17.4+k3s1 K3s supports [automated upgrades](/docs/upgrades/automated/). To enable this in air-gapped environments, you must ensure the required images are available in your private registry.
+As of v1.17.4+k3s1 K3s supports [automated upgrades](upgrades/automated.md). To enable this in air-gapped environments, you must ensure the required images are available in your private registry.
 
 You will need the version of rancher/k3s-upgrade that corresponds to the version of K3s you intend to upgrade to. Note, the image tag replaces the `+` in the K3s release with a `-` because Docker images do not support `+`.
 
@@ -118,4 +118,4 @@ rancher/system-upgrade-controller:v0.4.0
 rancher/kubectl:v0.17.0
 ```
 
-Once you have added the necessary rancher/k3s-upgrade, rancher/system-upgrade-controller, and rancher/kubectl images to your private registry, follow the [automated upgrades](/docs/upgrades/automated/) guide.
+Once you have added the necessary rancher/k3s-upgrade, rancher/system-upgrade-controller, and rancher/kubectl images to your private registry, follow the [automated upgrades](upgrades/automated.md) guide.

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -9,11 +9,11 @@ This page focuses on the options that can be used when you set up K3s for the fi
 - [K3s Binary](#configuration-with-binary)
 - [Configuration File](#configuration-file)
 
-For more advanced options, refer to [this page](/docs/advanced).
+For more advanced options, refer to [this page](advanced/advanced.md).
 
 ## Configuration with install script
 
-As mentioned in the [Quick-Start Guide](/docs/quick-start), you can use the installation script available at https://get.k3s.io to install K3s as a service on systemd and openrc based systems.
+As mentioned in the [Quick-Start Guide](quick-start/quick-start.md), you can use the installation script available at https://get.k3s.io to install K3s as a service on systemd and openrc based systems.
 
 You can use a combination of `INSTALL_K3S_EXEC`, `K3S_` environment variables, and command flags to configure the installation.
 
@@ -27,7 +27,7 @@ curl -sfL https://get.k3s.io | K3S_TOKEN=12345 sh -s - server --flannel-backend 
 curl -sfL https://get.k3s.io | sh -s - --flannel-backend none --token 12345
 ```
 
-For details on all environment variables, see [Environment Variables.](/docs/reference/env-variables)
+For details on all environment variables, see [Environment Variables.](reference/env-variables.md)
 
 ## Configuration with binary
 
@@ -52,8 +52,8 @@ The k3s agent can also be configured this way:
 k3s agent --server https://k3s.example.com --token mypassword
 ```
 
-For details on configuring the K3s server, see [Server Configuration.](/docs/reference/server-config)  
-For details on configuring the K3s agent, see [Agent Configuration.](/docs/reference/agent-config)  
+For details on configuring the K3s server, see [Server Configuration.](reference/server-config.md)  
+For details on configuring the K3s agent, see [Agent Configuration.](reference/agent-config.md)  
 You can also use the `--help` flag to see a list of all available options.
 
 ## Configuration File

--- a/docs/installation/ha.md
+++ b/docs/installation/ha.md
@@ -14,7 +14,7 @@ Single server clusters can meet a variety of use cases, but for environments whe
 * An **external datastore** (as opposed to the embedded SQLite datastore used in single-server setups)
 * A **fixed registration address** that is placed in front of the server nodes to allow agent nodes to register with the cluster
 
-For more details on how these components work together, refer to the [architecture section.](/docs/architecture#high-availability-with-an-external-db)
+For more details on how these components work together, refer to the [architecture section.](architecture/architecture.md#high-availability-with-an-external-db)
 
 Agents register through the fixed registration address, but after registration they establish a connection directly to one of the server nodes. This is a websocket connection initiated by the `k3s agent` process and it is maintained by a client-side load balancer running as part of the agent process.
 
@@ -28,14 +28,14 @@ Setting up an HA cluster requires the following steps:
 4. [Join agent nodes](#4-optional-join-agent-nodes)
 
 ### 1. Create an External Datastore
-You will first need to create an external datastore for the cluster. See the [Cluster Datastore Options](/docs/installation/datastore) documentation for more details.
+You will first need to create an external datastore for the cluster. See the [Cluster Datastore Options](datastore.md) documentation for more details.
 
 ### 2. Launch Server Nodes
-K3s requires two or more server nodes for this HA configuration. See the [Requirements](/docs/installation/requirements) guide for minimum machine requirements.
+K3s requires two or more server nodes for this HA configuration. See the [Requirements](requirements.md) guide for minimum machine requirements.
 
 When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore. The `token` parameter can also be used to set a deterministic token when adding nodes. When empty, this token will be generated automatically for further use.
 
-For example, a command like the following could be used to install the K3s server with a MySQL database as the external datastore and [set a token](/docs/reference/server-config#cluster-options):
+For example, a command like the following could be used to install the K3s server with a MySQL database as the external datastore and [set a token](reference/server-config.md#cluster-options):
 
 ```bash
 curl -sfL https://get.k3s.io | sh -s - server \
@@ -43,12 +43,12 @@ curl -sfL https://get.k3s.io | sh -s - server \
   --datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
 ```
 
-The datastore endpoint format differs based on the database type. For details, refer to the section on [datastore endpoint formats.](/docs/installation/datastore#datastore-endpoint-format-and-functionality)
+The datastore endpoint format differs based on the database type. For details, refer to the section on [datastore endpoint formats.](datastore.md#datastore-endpoint-format-and-functionality)
 
-To configure TLS certificates when launching server nodes, refer to the [datastore configuration guide.](/docs/installation/datastore#external-datastore-configuration-parameters)
+To configure TLS certificates when launching server nodes, refer to the [datastore configuration guide.](datastore.md#external-datastore-configuration-parameters)
 
 :::note
-The same installation options available to single-server installs are also available for high-availability installs. For more details, see the [Configuration Options](/docs/installation/configuration) documentation.
+The same installation options available to single-server installs are also available for high-availability installs. For more details, see the [Configuration Options](configuration.md) documentation.
 :::
 
 By default, server nodes will be schedulable and thus your workloads can get launched on them. If you wish to have a dedicated control plane where no user workloads will run, you can use taints. The `node-taint` parameter will allow you to configure nodes with taints, for example `--node-taint CriticalAddonsOnly=true:NoExecute`.
@@ -74,7 +74,7 @@ If the first server node was started without the `--token` CLI flag or `K3S_TOKE
 cat /var/lib/rancher/k3s/server/token
 ```
 
-Additional server nodes can then be added [using the token](/docs/reference/server-config#cluster-options):
+Additional server nodes can then be added [using the token](reference/server-config.md#cluster-options):
 
 ```bash
 curl -sfL https://get.k3s.io | sh -s - server \

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -3,17 +3,17 @@ title: "Installation"
 weight: 20
 ---
 
-This section contains instructions for installing K3s in various environments. Please ensure you have met the [Requirements](/docs/installation/requirements/) before you begin installing K3s.
+This section contains instructions for installing K3s in various environments. Please ensure you have met the [Requirements](requirements.md) before you begin installing K3s.
 
-[Configuration Options](/docs/installation/configuration/) provides guidance on the options available to you when installing K3s.
+[Configuration Options](configuration.md) provides guidance on the options available to you when installing K3s.
 
-[High Availability with an External DB](/docs/installation/ha/) details how to set up an HA K3s cluster backed by an external datastore such as MySQL, PostgreSQL, or etcd.
+[High Availability with an External DB](ha.md) details how to set up an HA K3s cluster backed by an external datastore such as MySQL, PostgreSQL, or etcd.
 
-[High Availability with Embedded DB](/docs/installation/ha-embedded/) details how to set up an HA K3s cluster that leverages a built-in distributed database.
+[High Availability with Embedded DB](ha-embedded.md) details how to set up an HA K3s cluster that leverages a built-in distributed database.
 
-[Air-Gap Installation](/docs/installation/airgap/) details how to set up K3s in environments that do not have direct access to the Internet.
+[Air-Gap Installation](airgap.md) details how to set up K3s in environments that do not have direct access to the Internet.
 
-[Disable Components Flags](/docs/installation/disable-flags/) details how to set up K3s with etcd only nodes and controlplane only nodes
+[Disable Components Flags](disable-flags.md) details how to set up K3s with etcd only nodes and controlplane only nodes
 
 ### Uninstalling
 

--- a/docs/installation/network-options.md
+++ b/docs/installation/network-options.md
@@ -6,7 +6,7 @@ weight: 25
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> **Note:** Please reference the [Networking](/docs/networking) page for information about CoreDNS, Traefik, and the Service LB.
+> **Note:** Please reference the [Networking](networking/networking.md) page for information about CoreDNS, Traefik, and the Service LB.
 
 By default, K3s will run with flannel as the CNI, using VXLAN as the default backend. To change the CNI, refer to the section on configuring a [custom CNI](#custom-cni). To change the flannel backend, refer to the flannel options section.
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -19,8 +19,8 @@ K3s is expected to work on most modern Linux systems.
 
 Some OSs have specific requirements:
 
-- If you are using **(Red Hat/CentOS) Enterprise Linux**, follow [these steps](/docs/advanced#additional-preparation-for-red-hatcentos-enterprise-linux) for additional setup.
-- If you are using **Raspberry Pi OS**, follow [these steps](/docs/advanced#additional-preparation-for-raspberry-pi-os) to switch to legacy iptables.
+- If you are using **(Red Hat/CentOS) Enterprise Linux**, follow [these steps](advanced/advanced.md#additional-preparation-for-red-hatcentos-enterprise-linux) for additional setup.
+- If you are using **Raspberry Pi OS**, follow [these steps](advanced/advanced.md#additional-preparation-for-raspberry-pi-os) to switch to legacy iptables.
 
 For more information on which OSs were tested with Rancher managed K3s clusters, refer to the [Rancher support and maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
@@ -31,7 +31,7 @@ Hardware requirements scale based on the size of your deployments. Minimum recom
 *    RAM: 512MB Minimum (we recommend at least 1GB)
 *    CPU: 1 Minimum
 
-[K3s Resource Profiling](/docs/reference/resource-profiling) captures the results of tests to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent. It also contains analysis about what has the biggest impact on K3s server and agent utilization, and how the cluster datastore can be protected from interference from agents and workloads.
+[K3s Resource Profiling](reference/resource-profiling.md) captures the results of tests to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent. It also contains analysis about what has the biggest impact on K3s server and agent utilization, and how the cluster datastore can be protected from interference from agents and workloads.
 
 #### Disks
 

--- a/docs/known-issues/known-issues.md
+++ b/docs/known-issues/known-issues.md
@@ -14,4 +14,4 @@ If you are running iptables in nftables mode instead of legacy you might encount
 
 ### Rootless Mode
 
-Running K3s with Rootless mode is experimental and has several [known issues.](/docs/advanced#known-issues-with-rootless-mode)
+Running K3s with Rootless mode is experimental and has several [known issues.](advanced/advanced.md#known-issues-with-rootless-mode)

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -5,9 +5,9 @@ weight: 35
 
 This page explains how CoreDNS, the Traefik Ingress controller, and Klipper service load balancer work within K3s.
 
-Refer to the [Installation Network Options](/docs/installation/network-options/) page for details on Flannel configuration options and backend selection, or how to set up your own CNI.
+Refer to the [Installation Network Options](installation/network-options.md) page for details on Flannel configuration options and backend selection, or how to set up your own CNI.
 
-For information on which ports need to be opened for K3s, refer to the [ Requirements.](/docs/installation/requirements/#networking)
+For information on which ports need to be opened for K3s, refer to the [ Requirements.](installation/requirements.md#networking)
 
 - [CoreDNS](#coredns)
 - [Traefik Ingress Controller](#traefik-ingress-controller)
@@ -28,11 +28,11 @@ If you don't install CoreDNS, you will need to install a cluster DNS provider yo
 
 [Traefik](https://traefik.io/) is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease. It simplifies networking complexity while designing, deploying, and running applications.
 
-Traefik is deployed by default when starting the server. For more information see [Auto Deploying Manifests](/docs/advanced#auto-deploying-manifests). The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml`.
+Traefik is deployed by default when starting the server. For more information see [Auto Deploying Manifests](advanced/advanced.md#auto-deploying-manifests). The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml`.
 
 The Traefik ingress controller will use ports 80 and 443 on the host (i.e. these will not be usable for HostPort or NodePort).
 
-The `traefik.yaml` file should not be edited manually, because k3s would overwrite it again once it is restarted. Instead you can customize Traefik by creating an additional `HelmChartConfig` manifest in `/var/lib/rancher/k3s/server/manifests`. For more details and an example see [Customizing Packaged Components with HelmChartConfig](/docs/helm#customizing-packaged-components-with-helmchartconfig). For more information on the possible configuration values, refer to the official [Traefik Helm Configuration Parameters.](https://github.com/traefik/traefik-helm-chart/tree/master/traefik).
+The `traefik.yaml` file should not be edited manually, because k3s would overwrite it again once it is restarted. Instead you can customize Traefik by creating an additional `HelmChartConfig` manifest in `/var/lib/rancher/k3s/server/manifests`. For more details and an example see [Customizing Packaged Components with HelmChartConfig](helm/helm.md#customizing-packaged-components-with-helmchartconfig). For more information on the possible configuration values, refer to the official [Traefik Helm Configuration Parameters.](https://github.com/traefik/traefik-helm-chart/tree/master/traefik).
 
 To disable it, start each server with the `--disable traefik` option.
 

--- a/docs/quick-start/quick-start.md
+++ b/docs/quick-start/quick-start.md
@@ -3,9 +3,9 @@ title: "Quick-Start Guide"
 weight: 10
 ---
 
-This guide will help you quickly launch a cluster with default options. The [installation section](/docs/installation) covers in greater detail how K3s can be set up.
+This guide will help you quickly launch a cluster with default options. The [installation section](installation/installation.md) covers in greater detail how K3s can be set up.
 
-For information on how K3s components work together, refer to the [architecture section.](/docs/architecture#high-availability-with-an-external-db)
+For information on how K3s components work together, refer to the [architecture section.](architecture/architecture.md#high-availability-with-an-external-db)
 
 :::note
 New to Kubernetes? The official Kubernetes docs already have some great tutorials outlining the basics [here](https://kubernetes.io/docs/tutorials/kubernetes-basics/).

--- a/docs/reference/binary-tools.md
+++ b/docs/reference/binary-tools.md
@@ -12,8 +12,8 @@ Command | Description
 `k3s kubectl`| Run an embedded [kubectl](https://kubernetes.io/docs/docs/reference/kubectl/overview/) CLI. If the `KUBECONFIG` environment variable is not set, this will automatically attempt to use the config file that is created at `/etc/rancher/k3s/k3s.yaml` when launching a K3s server node.
 `k3s crictl`| Run an embedded [crictl](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md). This is a CLI for interacting with Kubernetes's container runtime interface (CRI). Useful for debugging.
 `k3s ctr`| Run an embedded [ctr](https://github.com/projectatomic/containerd/blob/master/docs/cli.md). This is a CLI for containerd, the container daemon used by K3s. Useful for debugging.
-`k3s etcd-snapshot` | Perform on demand backups of the K3s cluster data and upload to S3. See [Backup and Restore](/docs/backup-restore#backup-and-restore-with-embedded-etcd-datastore-experimental) for more information.
-`k3s secrets-encrypt` | Configure K3s to encrypt secrets when storing them in the cluster. See [Secrets Encryption](/docs/security/secrets-encryption) for more information.
+`k3s etcd-snapshot` | Perform on demand backups of the K3s cluster data and upload to S3. See [Backup and Restore](backup-restore/backup-restore.md#backup-and-restore-with-embedded-etcd-datastore-experimental) for more information.
+`k3s secrets-encrypt` | Configure K3s to encrypt secrets when storing them in the cluster. See [Secrets Encryption](security/secrets-encryption.md) for more information.
 `k3s certificate` | Certificates management
 `k3s completion` | Generate shell completion scripts for k3s
 `k3s help`| Shows a list of commands or help for one command

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -3,7 +3,7 @@ title: Environment Variables
 weight: 3
 ---
 
-As mentioned in the [Quick-Start Guide](/docs/quick-start), you can use the installation script available at https://get.k3s.io to install K3s as a service on systemd and openrc based systems.
+As mentioned in the [Quick-Start Guide](quick-start/quick-start.md), you can use the installation script available at https://get.k3s.io to install K3s as a service on systemd and openrc based systems.
 
 The simplest form of this command is as follows:
 
@@ -23,7 +23,7 @@ When using this method to install K3s, the following environment variables can b
 | `INSTALL_K3S_BIN_DIR` | Directory to install K3s binary, links, and uninstall script to, or use `/usr/local/bin` as the default. |
 | `INSTALL_K3S_BIN_DIR_READ_ONLY` | If set to true will not write files to `INSTALL_K3S_BIN_DIR`, forces setting `INSTALL_K3S_SKIP_DOWNLOAD=true`. |
 | `INSTALL_K3S_SYSTEMD_DIR` | Directory to install systemd service and environment files to, or use `/etc/systemd/system` as the default. |
-| `INSTALL_K3S_EXEC` | Command with flags to use for launching K3s in the service. If the command is not specified, and the `K3S_URL` is set, it will default to "agent." If `K3S_URL` not set, it will default to "server." For help, refer to [this example.](/docs/installation/configuration#configuration-with-install-script) |
+| `INSTALL_K3S_EXEC` | Command with flags to use for launching K3s in the service. If the command is not specified, and the `K3S_URL` is set, it will default to "agent." If `K3S_URL` not set, it will default to "server." For help, refer to [this example.](installation/configuration.md#configuration-with-install-script) |
 | `INSTALL_K3S_NAME` | Name of systemd service to create, will default to 'k3s' if running k3s as a server and 'k3s-agent' if running k3s as an agent. If specified the name will be prefixed with 'k3s-'. |
 | `INSTALL_K3S_TYPE` | Type of systemd service to create, will default from the K3s exec command if not specified. |
 | `INSTALL_K3S_SELINUX_WARN` | If set to true will continue if k3s-selinux policy is not found. |

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -496,7 +496,7 @@ Ensure that the `--encryption-provider-config` argument is set as appropriate.
 <summary>Rationale</summary>
 `etcd` is a highly available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be encrypted at rest to avoid any disclosures.
 
-Detailed steps on how to configure secrets encryption in K3s are available in [Secrets Encryption](/docs/security/secrets-encryption).
+Detailed steps on how to configure secrets encryption in K3s are available in [Secrets Encryption](secrets-encryption.md).
 </details>
 
 ### Control 1.2.34
@@ -505,7 +505,7 @@ Ensure that encryption providers are appropriately configured.
 <summary>Rationale</summary>
 Where `etcd` encryption is used, it is important to ensure that the appropriate set of encryption providers is used. Currently, the `aescbc`, `kms` and `secretbox` are likely to be appropriate options.
 
-This can be remediated by passing a valid configuration to `k3s` as outlined above. Detailed steps on how to configure secrets encryption in K3s are available in [Secrets Encryption](/docs/security/secrets-encryption).
+This can be remediated by passing a valid configuration to `k3s` as outlined above. Detailed steps on how to configure secrets encryption in K3s are available in [Secrets Encryption](secrets-encryption.md).
 </details>
 
 ### Control 1.3.1
@@ -674,4 +674,4 @@ k3s server \
 
 ## Conclusion
 
-If you have followed this guide, your K3s cluster will be configured to comply with the CIS Kubernetes Benchmark. You can review the [CIS Benchmark Self-Assessment Guide](/docs/security/self-assessment) to understand the expectations of each of the benchmark's checks and how you can do the same on your cluster.
+If you have followed this guide, your K3s cluster will be configured to comply with the CIS Kubernetes Benchmark. You can review the [CIS Benchmark Self-Assessment Guide](self-assessment.md) to understand the expectations of each of the benchmark's checks and how you can do the same on your cluster.

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -7,5 +7,5 @@ This section describes the methodology and means of securing a K3s cluster. It's
 
 The documents below apply to CIS Kubernetes Benchmark v1.6.
 
-* [Hardening Guide](/docs/security/hardening-guide)
-* [CIS Benchmark Self-Assessment Guide](/docs/security/self-assessment)
+* [Hardening Guide](hardening-guide.md)
+* [CIS Benchmark Self-Assessment Guide](self-assessment.md)

--- a/docs/upgrades/automated.md
+++ b/docs/upgrades/automated.md
@@ -97,7 +97,7 @@ Third, the server-plan targets server nodes by specifying a label selector that 
 
 Fourth, the `prepare` step in the agent-plan will cause upgrade jobs for that plan to wait for the server-plan to complete before they execute.
 
-Fifth, both plans have the `version` field set to v1.22.11+k3s2. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [release channels](/docs/upgrades/manual/#release-channels). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
+Fifth, both plans have the `version` field set to v1.22.11+k3s2. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [release channels](manual.md#release-channels). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
 ```yaml
 apiVersion: upgrade.cattle.io/v1
 kind: Plan

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -9,7 +9,7 @@ You can upgrade K3s by using the installation script, or by manually installing 
 
 ### Release Channels
 
-Upgrades performed via the installation script or using our [automated upgrades](/docs/upgrades/automated/) feature can be tied to different release channels. The following channels are available:
+Upgrades performed via the installation script or using our [automated upgrades](automated.md) feature can be tied to different release channels. The following channels are available:
 
 | Channel |   Description  |
 |---------------|---------|

--- a/docs/upgrades/upgrades.md
+++ b/docs/upgrades/upgrades.md
@@ -5,9 +5,9 @@ weight: 25
 
 ### Upgrading your K3s cluster
 
-[Manual Upgrades](/docs/upgrades/manual) describes several techniques for upgrading your cluster manually. It can also be used as a basis for upgrading through third-party Infrastructure-as-Code tools like [Terraform](https://www.terraform.io/).
+[Manual Upgrades](manual.md) describes several techniques for upgrading your cluster manually. It can also be used as a basis for upgrading through third-party Infrastructure-as-Code tools like [Terraform](https://www.terraform.io/).
 
-[Automated Upgrades](/docs/upgrades/automated) describes how to perform Kubernetes-native automated upgrades using Rancher's [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller).
+[Automated Upgrades](automated.md) describes how to perform Kubernetes-native automated upgrades using Rancher's [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller).
 
 ### Version-specific caveats
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ module.exports = {
   title: 'K3s',
   tagline: '',
   url: 'https://k3s-io.github.io',
-  baseUrl: '/',
+  baseUrl: '/docs/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
This fixes the broken website at https://k3s-io.github.io/docs/ (the name of the repository) and now makes that the landing page (pending custom DNS configuration)
The actual docs will now sit at https://k3s-io.github.io/docs/docs.

This change broke all the internal links, because they were coded as absolute paths. 
Following [guidelines from Docusaurus](https://docusaurus.io/docs/markdown-features/links) these have been converted to "relative" links. This prevents having to fix the links in the future with any changes to the baseUrl

