### PR TITLE
Cleanup of Secrets Encryption Instructions, Docker Flag Fixes

### DIFF
--- a/docs/reference/agent-config.md
+++ b/docs/reference/agent-config.md
@@ -80,7 +80,7 @@ In this section, you'll learn how to configure the K3s agent.
 | Flag         | Description  |
 | ------------ | ------------ |
 | `--rootless` | Run rootless |
-| `--docker`   | Use cir-dockerd instead of containerd   |
+| `--docker`   | Use cri-dockerd instead of containerd   |
 
 ### Deprecated
 

--- a/docs/reference/agent-config.md
+++ b/docs/reference/agent-config.md
@@ -80,12 +80,12 @@ In this section, you'll learn how to configure the K3s agent.
 | Flag         | Description  |
 | ------------ | ------------ |
 | `--rootless` | Run rootless |
+| `--docker`   | Use cir-dockerd instead of containerd   |
 
 ### Deprecated
 
 | Flag                     | Environment Variable | Description                      |
 | ------------------------ | -------------------- | -------------------------------- |
-| `--docker`               | N/A                  | Use docker instead of containerd |
 | `--no-flannel`           | N/A                  | Use `--flannel-backend=none`     |
 | `--cluster-secret` value | `K3S_CLUSTER_SECRET` | Use `--token`                    |
 

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -193,7 +193,7 @@ the agent options are there because the server has the agent process embedded wi
 | `--rootless`           | Run rootless                             |
 | `--secrets-encryption` | Enable Secret encryption at rest         |
 | `--enable-pprof`       | Enable pprof endpoint on supervisor port |
-| `--docker`             | Use cir-dockerd instead of containerd    |
+| `--docker`             | Use cri-dockerd instead of containerd    |
 
 ### Deprecated Options
 

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -94,7 +94,6 @@ K3s agent options are available as server options because the server has the age
 
 | Flag                                 | Default                            | Description                                                        |
 | ------------------------------------ | ---------------------------------- | ------------------------------------------------------------------ | 
-| `--docker`                           | N/A                                | Use docker instead of containerd                                   |
 | `--container-runtime-endpoint` value | N/A                                | Disable embedded containerd and use alternative CRI implementation |
 | `--pause-image` value                | "docker.io/rancher/pause:3.1"      | Customized pause image for containerd or Docker sandbox            |
 | `--snapshotter` value                | N/A                                | Override default containerd snapshotter (default: "overlayfs")     |
@@ -194,6 +193,7 @@ the agent options are there because the server has the agent process embedded wi
 | `--rootless`           | Run rootless                             |
 | `--secrets-encryption` | Enable Secret encryption at rest         |
 | `--enable-pprof`       | Enable pprof endpoint on supervisor port |
+| `--docker`             | Use cir-dockerd instead of containerd    |
 
 ### Deprecated Options
 

--- a/docs/security/secrets-encryption.md
+++ b/docs/security/secrets-encryption.md
@@ -86,7 +86,14 @@ Starting K3s without encryption and enabling it at a later time is currently *no
   k3s secrets-encrypt prepare
   ```
 
-2. Kill and restart the K3s server with same arguments. If running k3s as a service you can use `systemctl restart k3s` or `rc-service k3s restart`.
+2. Kill and restart the K3s server with same arguments. If running K3s as a service:
+  ```bash
+  # If using systemd
+  systemctl restart k3s
+  # If using openrc
+  rc-service k3s restart
+  ```
+
 3. Rotate
 
   ```bash
@@ -124,7 +131,14 @@ To rotate secrets encryption keys on HA setups:
     k3s secrets-encrypt prepare
     ```
 
-3. Kill and restart S1 with same arguments. If running k3s as a service you can use `systemctl restart k3s` or `rc-service k3s restart`.
+3. Kill and restart S1 with same arguments. If running K3s as a service:
+  ```bash
+  # If using systemd
+  systemctl restart k3s
+  # If using openrc
+  rc-service k3s restart
+  ```
+
 4. Once S1 is up, kill and restart the S2 and S3
 
 5. Rotate on S1
@@ -165,7 +179,13 @@ To disable secrets encryption on a single-node cluster:
     k3s secrets-encrypt disable
     ```
 
-2. Kill and restart the K3s server with same arguments
+2. Kill and restart the K3s server with same arguments. If running K3s as a service:
+  ```bash
+  # If using systemd
+  systemctl restart k3s
+  # If using openrc
+  rc-service k3s restart
+  ```
 
 3. Reencrypt with flags
 
@@ -208,7 +228,14 @@ To disable secrets encryption on a HA cluster:
     k3s secrets-encrypt disable
     ```
 
-2. Kill and restart S1 with same arguments
+2. Kill and restart S1 with same arguments. If running K3s as a service:
+  ```bash
+  # If using systemd
+  systemctl restart k3s
+  # If using openrc
+  rc-service k3s restart
+  ```
+
 3. Once S1 is up, kill and restart the S2 and S3
 
 


### PR DESCRIPTION
- The `--docker` flag has been changed, it was experimental -> deprecated -> experimental again (now with cri-dockerd).
- Clarification on how to kill and restart K3s in secrets encryption.