### PR TITLE
Cleanup Introduction Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # K3s Website and Docs
 
-This repo contains the content of the K3s landing page and documentation. Please open an issue if you have suggestions for new content or edits. We also gladly accept community PRs. 
+This repo contains the content of the K3s documentation website found at https://docs.k3s.io. Please open an issue if you have suggestions for new content or edits. We also gladly accept community PRs. 
 
 The website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -49,16 +49,16 @@ To use Docker instead of containerd,
 1. Install Docker on the K3s node. One of Rancher's [Docker installation scripts](https://github.com/rancher/install-docker) can be used to install Docker:
 
     ```bash
-    curl https://releases.rancher.com/install-docker/19.03.sh | sh
+    curl https://releases.rancher.com/install-docker/20.10.sh | sh
     ```
 
-1. Install K3s using the `--docker` option:
+2. Install K3s using the `--docker` option:
 
     ```bash
     curl -sfL https://get.k3s.io | sh -s - --docker
     ```
 
-1. Confirm that the cluster is available:
+3. Confirm that the cluster is available:
 
     ```bash
     $ sudo k3s kubectl get pods --all-namespaces
@@ -71,7 +71,7 @@ To use Docker instead of containerd,
     kube-system   traefik-758cd5fc85-2wz97                 1/1     Running     0          43s
     ```
 
-1. Confirm that the Docker containers are running:
+4. Confirm that the Docker containers are running:
 
     ```bash
     $ sudo docker ps
@@ -88,37 +88,6 @@ To use Docker instead of containerd,
     4b1fddbe6ca6        rancher/pause:3.1         "/pause"                 About a minute ago   Up About a minute                       k8s_POD_local-path-provisioner-6d59f47c7-lncxn_kube-system_2dbd22bf-6ad9-4bea-a73d-620c90a6c1c1_0
     64d3517d4a95        rancher/pause:3.1         "/pause"
     ```
-
-#### Optional: Use crictl with Docker
-
-crictl provides a CLI for CRI-compatible container runtimes.
-
-If you would like to use crictl after installing K3s with the `--docker` option, install crictl using the [official documentation:](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) 
-
-```bash
-$ VERSION="v1.17.0"
-$ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
-$ sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin/crictl
-```
-
-Then start using crictl commands:
-
-```bash
-$ sudo crictl version
-Version:  0.1.0
-RuntimeName:  docker
-RuntimeVersion:  19.03.9
-RuntimeApiVersion:  1.40.0
-$ sudo crictl images
-IMAGE                            TAG                 IMAGE ID            SIZE
-rancher/coredns-coredns          1.6.3               c4d3d16fe508b       44.3MB
-rancher/klipper-helm             v0.2.5              6207e2a3f5225       136MB
-rancher/klipper-lb               v0.1.2              897ce3c5fc8ff       6.1MB
-rancher/library-traefik          1.7.19              aa764f7db3051       85.7MB
-rancher/local-path-provisioner   v0.0.11             9d12f9848b99f       36.2MB
-rancher/metrics-server           v0.3.6              9dd718864ce61       39.9MB
-rancher/pause                    3.1                 da86e6ba6ca19       742kB
-```
 
 ## Using etcdctl
 

--- a/docs/backup-restore/backup-restore.md
+++ b/docs/backup-restore/backup-restore.md
@@ -119,7 +119,9 @@ k3s supports a set of subcommands for working with your etcd snapshots.
 | prune       |  Remove snapshots that exceed the configured retention count |
 | save        |  Trigger an immediate etcd snapshot |
 
-*note* The `save` subcommand is the same as `k3s etcd-snapshot`. The latter will eventually be deprecated in favor of the former.
+:::note
+The `save` subcommand is the same as `k3s etcd-snapshot`. The latter will eventually be deprecated in favor of the former.
+:::
 
 These commands will perform as expected whether the etcd snapshots are stored locally or in an S3 compatible object store.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -23,7 +23,11 @@ K3s is a fully compliant Kubernetes distribution with the following enhancements
 * Lightweight storage backend based on sqlite3 as the default storage mechanism. etcd3, MySQL, Postgres are also available.
 * Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
 * Secure by default with reasonable defaults for lightweight environments.
-* Simple but powerful "batteries-included" features have been added, such as: a local storage provider, a service load balancer, a Helm controller, and the Traefik ingress controller.
+* Simple but powerful "batteries-included" features have been added, such as: 
+    * local storage provider 
+    * service load balancer
+    * Helm controller
+    * Traefik ingress controller.
 * Operation of all Kubernetes control plane components is encapsulated in a single binary and process. This allows K3s to automate and manage complex cluster operations like distributing certificates.
 * External dependencies have been minimized (just a modern kernel and cgroup mounts needed). K3s packages the required dependencies, including:
     * containerd

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,20 +20,21 @@ Great for:
 K3s is a fully compliant Kubernetes distribution with the following enhancements:
 
 * Packaged as a single binary.
-* Lightweight storage backend based on sqlite3 as the default storage mechanism. etcd3, MySQL, Postgres also still available.
+* Lightweight storage backend based on sqlite3 as the default storage mechanism. etcd3, MySQL, Postgres are also available.
 * Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
 * Secure by default with reasonable defaults for lightweight environments.
 * Simple but powerful "batteries-included" features have been added, such as: a local storage provider, a service load balancer, a Helm controller, and the Traefik ingress controller.
 * Operation of all Kubernetes control plane components is encapsulated in a single binary and process. This allows K3s to automate and manage complex cluster operations like distributing certificates.
 * External dependencies have been minimized (just a modern kernel and cgroup mounts needed). K3s packages the required dependencies, including:
     * containerd
-    * Flannel
+    * Flannel (CNI)
     * CoreDNS
-    * CNI
-    * Host utilities (iptables, socat, etc)
-    * Ingress controller (traefik)
-    * Embedded service loadbalancer
+    * Traefik (Ingress)
+    * Klipper-lb (Service LB)
     * Embedded network policy controller
+    * Embedded local-path-provisioner
+    * Host utilities (iptables, socat, etc)
+
 
 # What's with the name?
 


### PR DESCRIPTION
- Add more info in the README
- Cleanup docker section, we already bundle crictl in K3s, no need to install it. 
- Reword sections of the Introduction Page
  - Add bullet pointed list instead of a long sentence
  - Rework bullet points to be more descriptive about each component. 
