### PR TITLE
Cleanup the SELinux and Helm sections

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -355,21 +355,22 @@ sudo docker run \
 
 ## SELinux Support
 
-_Supported as of v1.19.4+k3s1. Experimental as of v1.17.4+k3s1._
-
-If you are installing K3s on a system where SELinux is enabled by default (such as CentOS), you must ensure the proper SELinux policies have been installed. 
-
-### Automatic Installation
-
 :::info Version Gate
 
-Available as of v1.19.3+k3s2
+Available as of v1.19.4+k3s1
 
 :::
 
+If you are installing K3s on a system where SELinux is enabled by default (such as CentOS), you must ensure the proper SELinux policies have been installed. 
+
+<Tabs>
+<TabItem value="Automatic Installation" default>
+
 The [install script](installation/configuration#options-for-installation-with-script) will automatically install the SELinux RPM from the Rancher RPM repository if on a compatible system if not performing an air-gapped install. Automatic installation can be skipped by setting `INSTALL_K3S_SKIP_SELINUX_RPM=true`.
 
-### Manual Installation
+</TabItem>
+
+<TabItem value="Manual Installation" default>
 
 The necessary policies can be installed with the following commands:
 ```bash
@@ -378,14 +379,11 @@ yum install -y https://rpm.rancher.io/k3s/latest/common/centos/7/noarch/k3s-seli
 ```
 
 To force the install script to log a warning rather than fail, you can set the following environment variable: `INSTALL_K3S_SELINUX_WARN=true`.
+</TabItem>
+</Tabs>
 
-### Enabling and Disabling SELinux Enforcement
+### Enabling SELinux Enforcement
 
-The way that SELinux enforcement is enabled or disabled depends on the K3s version.
-
-<Tabs>
-<TabItem value="K3s v1.19.1+k3s1" default>
-  
 To leverage SELinux, specify the `--selinux` flag when starting K3s servers and agents.
   
 This option can also be specified in the K3s [configuration file](#).
@@ -394,22 +392,7 @@ This option can also be specified in the K3s [configuration file](#).
 selinux: true
 ```
 
-The `--disable-selinux` option should not be used. It is deprecated and will be either ignored or will be unrecognized, resulting in an error, in future minor releases.
-
 Using a custom `--data-dir` under SELinux is not supported. To customize it, you would most likely need to write your own custom policy. For guidance, you could refer to the [containers/container-selinux](https://github.com/containers/container-selinux) repository, which contains the SELinux policy files for Container Runtimes, and the [rancher/k3s-selinux](https://github.com/rancher/k3s-selinux) repository, which contains the SELinux policy for K3s.
-
-</TabItem>
-
-<TabItem value="K3s before v1.19.1+k3s1">
-
-SELinux is automatically enabled for the built-in containerd.
-
-To turn off SELinux enforcement in the embedded containerd, launch K3s with the `--disable-selinux` flag.
-
-Using a custom `--data-dir` under SELinux is not supported. To customize it, you would most likely need to write your own custom policy. For guidance, you could refer to the [containers/container-selinux](https://github.com/containers/container-selinux) repository, which contains the SELinux policy files for Container Runtimes, and the [rancher/k3s-selinux](https://github.com/rancher/k3s-selinux) repository, which contains the SELinux policy for K3s .
-
-</TabItem>
-</Tabs>
 
 ## Enabling Lazy Pulling of eStargz (Experimental)
 

--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -3,7 +3,7 @@ title: Helm
 weight: 42
 ---
 
-Helm is the package management tool of choice for Kubernetes. Helm charts provide templating syntax for Kubernetes YAML manifest documents. With Helm we can create configurable deployments instead of just using static files. For more information about creating your own catalog of deployments, check out the docs at [https://helm.sh/docs/intro/quickstart/](https://helm.sh/docs/intro/quickstart/).
+Helm is the package management tool of choice for Kubernetes. Helm charts provide templating syntax for Kubernetes YAML manifest documents. With Helm, we can create configurable deployments instead of just using static files. For more information about creating your own catalog of deployments, check out the docs at [https://helm.sh/docs/intro/quickstart/](https://helm.sh/docs/intro/quickstart/).
 
 K3s does not require any special configuration to use with Helm command-line tools. Just be sure you have properly set up your kubeconfig as per the section about [cluster access](cluster-access/cluster-access.md). K3s does include some extra functionality to make deploying both traditional Kubernetes resource manifests and Helm Charts even easier with the [rancher/helm-release CRD.](#using-the-helm-crd)
 
@@ -12,7 +12,7 @@ This section covers the following topics:
 - [Automatically Deploying Manifests and Helm Charts](#automatically-deploying-manifests-and-helm-charts)
 - [Using the Helm CRD](#using-the-helm-crd)
 - [Customizing Packaged Components with HelmChartConfig](#customizing-packaged-components-with-helmchartconfig)
-- [Upgrading from Helm v2](#upgrading-from-helm-v2)
+- [Migrating from Helm v2](#migrating-from-helm-v2)
 
 ### Automatically Deploying Manifests and Helm Charts
 
@@ -21,8 +21,6 @@ Any Kubernetes manifests found in `/var/lib/rancher/k3s/server/manifests` will a
 It is also possible to deploy Helm charts as AddOns. K3s includes a [Helm Controller](https://github.com/rancher/helm-controller/) that manages Helm charts using a HelmChart Custom Resource Definition (CRD).
 
 ### Using the Helm CRD
-
-> **Note:** K3s versions through v0.5.0 used `k3s.cattle.io/v1` as the apiVersion for HelmCharts. This has been changed to `helm.cattle.io/v1` for later versions.
 
 The [HelmChart resource definition](https://github.com/rancher/helm-controller#helm-controller) captures most of the options you would normally pass to the `helm` command-line tool. Here's an example of how you might deploy Grafana from the default chart repository, overriding some of the default chart values. Note that the HelmChart resource itself is in the `kube-system` namespace, but the chart's resources will be deployed to the `monitoring` namespace.
 
@@ -64,16 +62,16 @@ spec:
 | spec.valuesContent |   | Override complex default Chart values via YAML file content | `--values` |
 | spec.chartContent |   | Base64-encoded chart archive .tgz - overrides spec.chart | CHART |
 
-Content placed in `/var/lib/rancher/k3s/server/static/` can be accessed anonymously via the Kubernetes APIServer from within the cluster. This URL can be templated using the special variable `%{KUBERNETES_API}%` in the `spec.chart` field. For example, the packaged Traefik component loads its chart from `https://%{KUBERNETES_API}%/static/charts/traefik-1.81.0.tgz`.
+Content placed in `/var/lib/rancher/k3s/server/static/` can be accessed anonymously via the Kubernetes APIServer from within the cluster. This URL can be templated using the special variable `%{KUBERNETES_API}%` in the `spec.chart` field. For example, the packaged Traefik component loads its chart from `https://%{KUBERNETES_API}%/static/charts/traefik-12.0.000.tgz`.
 
 **Note:** The `name` field should follow the Helm chart naming conventions. Refer [here](https://helm.sh/docs/chart_best_practices/conventions/#chart-names) to learn more.
 
->**Notice on File Naming Requirements:** `HelmChart` and `HelmChartConfig` manifest filenames should adhere to Kubernetes object [naming restrictions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). The Helm Controller uses filenames to create objects; therefore, the filename must also align with the restrictions. Any related errors can be observed in the rke2-server logs. The example below is an error generated from using underscores:
+>**Notice on File Naming Requirements:** `HelmChart` and `HelmChartConfig` manifest filenames should adhere to Kubernetes object [naming restrictions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). The Helm Controller uses filenames to create objects; therefore, the filename must also align with the restrictions. Any related errors can be observed in the k3s-server logs. The example below is an error generated from using underscores:
 ```
 level=error msg="Failed to process config: failed to process 
-/var/lib/rancher/rke2/server/manifests/rke2_ingress_daemonset.yaml: 
-Addon.k3s.cattle.io \"rke2_ingress_daemonset\" is invalid: metadata.name: 
-Invalid value: \"rke2_ingress_daemonset\": a lowercase RFC 1123 subdomain 
+/var/lib/rancher/k3s/server/manifests/k3s_ingress_daemonset.yaml: 
+Addon.k3s.cattle.io \"k3s_ingress_daemonset\" is invalid: metadata.name: 
+Invalid value: \"k3s_ingress_daemonset\": a lowercase RFC 1123 subdomain 
 must consist of lower case alphanumeric characters, '-' or '.', and must 
 start and end with an alphanumeric character (e.g. 'example.com', regex 
 used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]
@@ -104,11 +102,7 @@ spec:
   valuesContent: |-
     image:
       name: traefik
-      tag: v2.6.1
-    proxyProtocol:
-      enabled: true
-      trustedIPs:
-        - 10.0.0.0/8
+      tag: v2.8.5
     forwardedHeaders:
       enabled: true
       trustedIPs:
@@ -118,10 +112,12 @@ spec:
       permanentRedirect: false
 ```
 
-### Upgrading from Helm v2
+### Migrating from Helm v2
 
-> **Note:** K3s versions starting with v1.17.0+k3s.1 support Helm v3, and will use it by default. Helm v2 charts can be used by setting `helmVersion: v2` in the spec.
+:::info Version Gate
+K3s versions starting with v1.17.0+k3s.1 support Helm v3, and use it by default. Helm v2 charts are still supported by setting `helmVersion: v2` in the spec.
+:::
 
-If you were using Helm v2 in previous versions of K3s, you may upgrade to v1.17.0+k3s.1 or newer and Helm 2 will still function. If you wish to migrate to Helm 3, [this](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) blog post by Helm explains how to use a plugin to successfully migrate. Refer to the official Helm 3 documentation [here](https://helm.sh/docs/) for more information. K3s will handle either Helm v2 or Helm v3 as of v1.17.0+k3s.1. Just be sure you have properly set your kubeconfig as per the examples in the section about [cluster access.](cluster-access/cluster-access.md)
+K3s can handle either Helm v2 or Helm v3. If you wish to migrate to Helm v3, [this](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) blog post by Helm explains how to use a plugin to successfully migrate. Refer to the official Helm 3 documentation [here](https://helm.sh/docs/) for more information. Just be sure you have properly set your kubeconfig as per the section about [cluster access.](../cluster-access/cluster-access.md)
 
 Note that Helm 3 no longer requires Tiller and the `helm init` command. Refer to the official documentation for details.

--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -64,7 +64,9 @@ spec:
 
 Content placed in `/var/lib/rancher/k3s/server/static/` can be accessed anonymously via the Kubernetes APIServer from within the cluster. This URL can be templated using the special variable `%{KUBERNETES_API}%` in the `spec.chart` field. For example, the packaged Traefik component loads its chart from `https://%{KUBERNETES_API}%/static/charts/traefik-12.0.000.tgz`.
 
-**Note:** The `name` field should follow the Helm chart naming conventions. Refer [here](https://helm.sh/docs/chart_best_practices/conventions/#chart-names) to learn more.
+:::note
+The `name` field should follow the Helm chart naming conventions. Refer [here](https://helm.sh/docs/chart_best_practices/conventions/#chart-names) to learn more.
+:::
 
 >**Notice on File Naming Requirements:** `HelmChart` and `HelmChartConfig` manifest filenames should adhere to Kubernetes object [naming restrictions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). The Helm Controller uses filenames to create objects; therefore, the filename must also align with the restrictions. Any related errors can be observed in the k3s-server logs. The example below is an error generated from using underscores:
 ```
@@ -82,13 +84,15 @@ used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]
 
 :::info Version Gate
 
-Available as of [v1.19.0+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.19.0%2Bk3s1)
+Available as of [v1.19.1+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.19.1%2Bk3s1)
 
 :::
 
 To allow overriding values for packaged components that are deployed as HelmCharts (such as Traefik), K3s supports customizing deployments via a HelmChartConfig resources. The HelmChartConfig resource must match the name and namespace of its corresponding HelmChart, and it supports providing additional `valuesContent`, which is passed to the `helm` command as an additional value file.
 
-> **Note:** HelmChart `spec.set` values override HelmChart and HelmChartConfig `spec.valuesContent` settings.
+:::note
+HelmChart `spec.set` values override HelmChart and HelmChartConfig `spec.valuesContent` settings.
+:::
 
 For example, to customize the packaged Traefik ingress configuration, you can create a file named `/var/lib/rancher/k3s/server/manifests/traefik-config.yaml` and populate it with the following content:
 
@@ -115,9 +119,11 @@ spec:
 ### Migrating from Helm v2
 
 :::info Version Gate
-K3s versions starting with v1.17.0+k3s.1 support Helm v3, and use it by default. Helm v2 charts are still supported by setting `helmVersion: v2` in the spec.
+As of [v1.17.0+k3s.1](https://github.com/k3s-io/k3s/releases/tag/v1.17.0%2Bk3s.1) Helm v3 is supported and used by default.
 :::
 
 K3s can handle either Helm v2 or Helm v3. If you wish to migrate to Helm v3, [this](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) blog post by Helm explains how to use a plugin to successfully migrate. Refer to the official Helm 3 documentation [here](https://helm.sh/docs/) for more information. Just be sure you have properly set your kubeconfig as per the section about [cluster access.](../cluster-access/cluster-access.md)
 
-Note that Helm 3 no longer requires Tiller and the `helm init` command. Refer to the official documentation for details.
+:::note
+Helm 3 no longer requires Tiller and the `helm init` command. Refer to the official documentation for details.
+:::


### PR DESCRIPTION
Cleaned up the SELinux section, removing old instructions on pre-1.19 versions, using tabs to default to automatic installation (what most people will be using)

**OLD:**
![image](https://user-images.githubusercontent.com/11727736/198070396-9c975c5e-a058-421f-9626-b1bf168286c9.png)
**NEW:**
![image](https://user-images.githubusercontent.com/11727736/198070583-4d2365f5-3f6a-4106-908f-25cf927f535b.png)

Cleanup the Helm page, removing reference to very old K3s versions and fixing spelling errors.

Signed-off-by: Derek Nola <derek.nola@suse.com>