### PR TITLE
Add details about flag mismatch

### DIFF
--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -57,14 +57,10 @@ For details on configuring the K3s agent, see [Agent Configuration.](reference/a
 You can also use the `--help` flag to see a list of all available options.
 
 :::info Matching Flags
-
 It is important to match critical flags on your server/agent installations. For example, if you use the flag
-`--disable servicelb` or `--cluster-cidr=10.42.0.0/16` on your master node, but don't set it on your other installs,
-your nodes will fail to join. They may print errors such as 
-`starting kubernetes: preparing server: failed to validate server configuration: critical configuration value mismatch`.
-
-
-
+`--disable servicelb` or `--cluster-cidr=10.42.0.0/16` on your master node, but don't set it on other server nodes, the nodes will fail to join. They will print errors with:
+`failed to validate server configuration: critical configuration value mismatch.`
+:::
 ## Configuration File
 
 :::info Version Gate

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -56,6 +56,15 @@ For details on configuring the K3s server, see [Server Configuration.](reference
 For details on configuring the K3s agent, see [Agent Configuration.](reference/agent-config.md)  
 You can also use the `--help` flag to see a list of all available options.
 
+:::info Matching Flags
+
+It is important to match critical flags on your server/agent installations. For example, if you use the flag
+`--disable servicelb` or `--cluster-cidr=10.42.0.0/16` on your master node, but don't set it on your other installs,
+your nodes will fail to join. They may print errors such as 
+`starting kubernetes: preparing server: failed to validate server configuration: critical configuration value mismatch`.
+
+
+
 ## Configuration File
 
 :::info Version Gate


### PR DESCRIPTION
There is a very hard to debug edge cases where if server flags don't match, the error message is highly misleading referencing Cluster CA certs.

Adding first draft of helpful notes for other users. I am open to all suggestions and edits from maintainers - thank you for a great project!

## Details

I burned about a day trying to debug TLS certs, rotate the CA and fight with the node installs. My k3s would fail to come up with errors:
```
Nov 01 23:09:14 elude2 systemd[1]: Starting Lightweight Kubernetes...
Nov 01 23:09:14 elude2 sh[371507]: + /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service
Nov 01 23:09:14 elude2 sh[371508]: Failed to get unit file state for nm-cloud-setup.service: No such file or directory
Nov 01 23:09:14 elude2 k3s[371511]: time="2022-11-01T23:09:14-06:00" level=info msg="Starting k3s v1.25.3+k3s1 (f2585c16)"
Nov 01 23:09:14 elude2 k3s[371511]: time="2022-11-01T23:09:14-06:00" level=warning msg="Cluster CA certificate is not trusted by the host CA bundle, but the token does not include a CA hash. Use the full token from the server's node-token file to enable>
Nov 01 23:09:14 elude2 k3s[371511]: time="2022-11-01T23:09:14-06:00" level=info msg="Managed etcd cluster not yet initialized"
Nov 01 23:09:14 elude2 k3s[371511]: time="2022-11-01T23:09:14-06:00" level=warning msg="Cluster CA certificate is not trusted by the host CA bundle, but the token does not include a CA hash. Use the full token from the server's node-token file to enable>
Nov 01 23:09:14 elude2 k3s[371511]: time="2022-11-01T23:09:14-06:00" level=fatal msg="starting kubernetes: preparing server: failed to validate server configuration: critical configuration value mismatch"
Nov 01 23:09:14 elude2 systemd[1]: k3s.service: Main process exited, code=exited, status=1/FAILURE
Nov 01 23:09:14 elude2 systemd[1]: k3s.service: Failed with result 'exit-code'.
Nov 01 23:09:14 elude2 systemd[1]: Failed to start Lightweight Kubernetes.
```

After a ton of digging, I realized that perhaps my install commands needed to match. It turns out the flags need to be passed on all nodes.

## Install Commands

Master 1:
```
curl -sfL https://get.k3s.io | K3S_TOKEN=VE5Q255N8DUN2D89Y7DUP8W7 INSTALL_K3S_EXEC="server --cluster-init --flannel-backend none --disable-network-policy --cluster-cidr=10.42.0.0/16  --disable servicelb --write-kubeconfig-mode 644" sh -s -
```

Master 2 and 3:
```
curl -sfL https://get.k3s.io | K3S_TOKEN=VE5Q255N8DUN2D89Y7DUP8W7 sh -s - server --server https://192.168.4.22:6443 --write-kubeconfig-mode 644 --disable servicelb --cluster-cidr=10.42.0.0/16 --flannel-backend none --disable-network-policy
```

Signed-off-by: Ivan Smirnov <isgsmirnov@gmail.com>