### PR TITLE
Update an invalid link in network-options.md

### DIFF
--- a/docs/installation/network-options.md
+++ b/docs/installation/network-options.md
@@ -66,8 +66,8 @@ You should see that IP forwarding is set to true.
 </TabItem>
 <TabItem value="Calico" default>
 
-Follow the [Calico CNI Plugins Guide](https://docs.projectcalico.org/master/docs/reference/cni-plugin/configuration). Modify the Calico YAML so that IP forwarding is allowed in the container_settings section, for example:
-
+Follow the [Calico CNI Plugins Guide](https://projectcalico.docs.tigera.io/master/reference/cni-plugin/configuration). Modify the Calico YAML so that IP forwarding is allowed in the container_settings section, for example:
+  
 ```yaml
 "container_settings": {
               "allow_ip_forwarding": true


### PR DESCRIPTION
This link address (https://docs.projectcalico.org/master/docs/reference/cni-plugin/configuration) is not valid anymore. Seems the right one should be: https://projectcalico.docs.tigera.io/master/reference/cni-plugin/configuration
Signed-off-by: Karl Cai <abc123467@yahoo.com>