### PR TITLE
Storage Page cleanup + Certificate rotation

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -30,9 +30,32 @@ This section contains advanced information describing the different ways you can
 
 ## Certificate Rotation
 
+### Automatic rotation
 By default, certificates in K3s expire in 12 months.
 
 If the certificates are expired or have fewer than 90 days remaining before they expire, the certificates are rotated when K3s is restarted.
+
+### Manual rotation
+
+To rotate the certificates manually, use the `k3s certificate rotate` subcommand:
+
+```bash
+# Stop K3s
+systemctl stop k3s
+# Rotate certificates
+k3s certificate rotate
+# Start K3s
+systemctl start k3s
+```
+
+Individual or lists of certificates can be rotated by specifying the certificate name:
+
+```bash
+k3s certificate rotate --service <SERVICE>,<SERVICE>
+```
+
+The following certificates can be rotated: `admin`, `api-server`, `controller-manager`, `scheduler`, `k3s-controller`, `k3s-server`, `cloud-controller`, `etcd`, `auth-proxy`, `kubelet`, `kube-proxy`.
+
 
 ## Auto-Deploying Manifests
 

--- a/docs/reference/binary-tools.md
+++ b/docs/reference/binary-tools.md
@@ -14,6 +14,6 @@ Command | Description
 `k3s ctr`| Run an embedded [ctr](https://github.com/projectatomic/containerd/blob/master/docs/cli.md). This is a CLI for containerd, the container daemon used by K3s. Useful for debugging.
 `k3s etcd-snapshot` | Perform on demand backups of the K3s cluster data and upload to S3. See [Backup and Restore](backup-restore/backup-restore.md#backup-and-restore-with-embedded-etcd-datastore-experimental) for more information.
 `k3s secrets-encrypt` | Configure K3s to encrypt secrets when storing them in the cluster. See [Secrets Encryption](security/secrets-encryption.md) for more information.
-`k3s certificate` | Certificates management
+`k3s certificate` | Certificates management. See [Certificate Rotation](advanced/advanced.md#certificate-rotation) for more information.
 `k3s completion` | Generate shell completion scripts for k3s
 `k3s help`| Shows a list of commands or help for one command

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -9,7 +9,7 @@ A persistent volume (PV) is a piece of storage in the Kubernetes cluster, while 
 
 This page describes how to set up persistent storage with a local storage provider, or with [Longhorn.](#setting-up-longhorn)
 
-# What's changed in K3s storage?
+## What's different about K3s storage?
 
 K3s removes several optional volume plugins and all built-in (sometimes referred to as "in-tree") cloud providers. We do this in order to achieve a smaller binary size and to avoid dependence on third-party cloud or data center technologies and services, which may not be available in many K3s use cases. We are able to do this because their removal affects neither core Kubernetes functionality nor conformance.
 
@@ -29,7 +29,7 @@ Both components have out-of-tree alternatives that can be used with K3s: The Kub
 
 Kubernetes maintainers are actively migrating in-tree volume plugins to CSI drivers. For more information on this migration, please refer [here](https://kubernetes.io/blog/2021/12/10/storage-in-tree-to-csi-migration-status-update/).
 
-# Setting up the Local Storage Provider
+## Setting up the Local Storage Provider
 K3s comes with Rancher's Local Path Provisioner and this enables the ability to create persistent volume claims out of the box using local storage on the respective node. Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/rancher/local-path-provisioner/blob/master/README.md#usage).
 
 Create a hostPath backed persistent volume claim and a pod to utilize it:
@@ -91,18 +91,18 @@ kubectl get pvc
 
 The status should be Bound for each.
 
-# Setting up Longhorn
+## Setting up Longhorn
 
 :::caution
 
-At this time Longhorn only supports amd64 and arm64 (experimental).
+Longhorn does not support ARM32.
 
 ::: 
 
 
-K3s supports [Longhorn](https://github.com/longhorn/longhorn). Longhorn is an open-source distributed block storage system for Kubernetes.
+K3s supports [Longhorn](https://github.com/longhorn/longhorn), an open-source distributed block storage system for Kubernetes.
 
-Below we cover a simple example. For more information, refer to the official documentation [here](https://longhorn.io/docs/latest/).
+Below we cover a simple example. For more information, refer to the [official documentation](https://longhorn.io/docs/latest/).
 
 Apply the longhorn.yaml to install Longhorn:
 

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -93,13 +93,16 @@ The status should be Bound for each.
 
 # Setting up Longhorn
 
-:::caution (pending change - longhorn may support arm64 and armhf in the future.)
+:::caution
 
-> **Note:** At this time Longhorn only supports amd64 and arm64 (experimental).
+At this time Longhorn only supports amd64 and arm64 (experimental).
+
+::: 
+
 
 K3s supports [Longhorn](https://github.com/longhorn/longhorn). Longhorn is an open-source distributed block storage system for Kubernetes.
 
-Below we cover a simple example. For more information, refer to the official documentation [here](https://github.com/longhorn/longhorn/blob/master/README.md).
+Below we cover a simple example. For more information, refer to the official documentation [here](https://longhorn.io/docs/latest/).
 
 Apply the longhorn.yaml to install Longhorn:
 

--- a/docs/upgrades/automated.md
+++ b/docs/upgrades/automated.md
@@ -42,7 +42,7 @@ The controller can be configured and customized via the previously mentioned con
 
 
 ### Configure plans
-It is recommended that you minimally create two plans: a plan for upgrading server (master) nodes and a plan for upgrading agent (worker) nodes. As needed, you can create additional plans to control the rollout of the upgrade across nodes. The following two example plans will upgrade your cluster to K3s v1.22.11+k3s2. Once the plans are created, the controller will pick them up and begin to upgrade your cluster.
+It is recommended that you minimally create two plans: a plan for upgrading server (master) nodes and a plan for upgrading agent (worker) nodes. As needed, you can create additional plans to control the rollout of the upgrade across nodes. The following two example plans will upgrade your cluster to K3s v1.24.6+k3s1. Once the plans are created, the controller will pick them up and begin to upgrade your cluster.
 ```yaml
 # Server plan
 apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.22.11+k3s2
+  version: v1.24.6+k3s1
 ---
 # Agent plan
 apiVersion: upgrade.cattle.io/v1
@@ -85,7 +85,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.22.11+k3s2
+  version: v1.24.6+k3s1
 ```
 There are a few important things to call out regarding these plans:
 
@@ -97,7 +97,7 @@ Third, the server-plan targets server nodes by specifying a label selector that 
 
 Fourth, the `prepare` step in the agent-plan will cause upgrade jobs for that plan to wait for the server-plan to complete before they execute.
 
-Fifth, both plans have the `version` field set to v1.22.11+k3s2. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [release channels](manual.md#release-channels). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
+Fifth, both plans have the `version` field set to v1.24.6+k3s1. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [release channels](manual.md#release-channels). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
 ```yaml
 apiVersion: upgrade.cattle.io/v1
 kind: Plan


### PR DESCRIPTION
- Fixed bug around the `Warning` notice consuming the entire page in yellow
- Set proper markdown headers to be picked up by the sidebar
- Reworded wording of the Longhorn section.
- Added section on the `k3s certificate rotate` command