### PR TITLE
Add section on CIS 1.23, PSA in K3s 1.25+ in hardening guide

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -41,16 +41,15 @@ kernel.keys.root_maxbytes=25000000
 
 The runtime requirements to comply with the CIS Benchmark are centered around pod security (via PSP or PSA), network policies and API Server auditing logs. These are outlined in this section.
 
-By default, K3s does not apply any pod security or network policies. However, K3s ships with a controller that is meant to apply a given set of network policies. The same setup applies API Server auditing logs, K3s doesn't enable them by default, so audit log configuration and audit policy must be created manually. By default, K3s runs with the `NodeRestriction` admission controller. 
+By default, K3s does not include any pod security or network policies. However, K3s ships with a controller that will enforce network policies, if any are created. K3s doesn't enable auditing by default, so audit log configuration and audit policy must be created manually. By default, K3s runs with the both the `PodSecurity` and `NodeRestriction` admission controllers enabled, among others.
 
 ### Pod Security
 
 <Tabs>
 <TabItem value="v1.25 and Newer" default>
 
-K3s v1.25 and newer support [Pod Security Admissions (PSAs)](https://kubernetes.io/docs/concepts/security/pod-security-admission/) for controlling pod security. PSAs are enabled by passing the following flags to the K3s server:
+K3s v1.25 and newer support [Pod Security Admissions (PSAs)](https://kubernetes.io/docs/concepts/security/pod-security-admission/) for controlling pod security. PSAs are enabled by passing the following flag to the K3s server:
 ```
---kube-apiserver-arg="enable-admission-plugins=NodeRestriction"
 --kube-apiserver-arg="admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml"
 ```
 
@@ -573,7 +572,6 @@ The configuration below should be placed in the [configuration file](../installa
 protect-kernel-defaults: true
 secrets-encryption: true
 kube-apiserver-arg:
-  - 'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount'
   - 'admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml'
   - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
   - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -132,7 +132,7 @@ spec:
 
 For the above PSP to be effective, we need to create a ClusterRole and a ClusterRoleBinding. We also need to include a "system unrestricted policy" which is needed for system-level pods that require additional privileges, and an additional policy that allows sysctls necessary for servicelb to function properly.
 
-Combining the configuration above with the [Network Policy](#networkpolicies) described in the next section, a single file can be placed in the `/var/lib/rancher/k3s/server/manifests` directory. Here is an example of a `policy.yaml` file. 
+Combining the configuration above with the [Network Policy](#networkpolicies) described in the next section, a single file can be placed in the `/var/lib/rancher/k3s/server/manifests` directory. Here is an example of a `policy.yaml` file: 
 
 ```yaml
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Addresses https://github.com/k3s-io/docs/issues/41
- Use tabs to rework hardening guide sections
- Section on K3s 1.25+ and the relevant PSA configuration
- Move the K3s "hardened flags" up on the guide, push reference details down. 
- Hardened flags are now provided as a `config.yaml`, the user is already doing prep work on the node, placing a premade config.yaml is inline with other prep work.