### PR TITLE
Add Workflow dispatch with dev build options

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,22 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch:
+    inputs:
+      dev_branch:
+            description: 'Change the build branch for deployment to personal website for PR previewing'
+            required: false
+            default: 'main'
+            type: string
+  
 jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.dev_branch }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -19,7 +28,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website
+        if: ${{ github.repository_owner == 'k3s-io' }}
         run: yarn build
+      
+      # Developer build used for PR reviews, deploys website with with a custom `baseUrl` for previewing
+      - name: Build website (dev)
+        if: ${{ github.repository_owner != 'k3s-io' && github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "replacing baseUrl in docusaurus.config.js with ${{ github.event.repository.name }}"
+          sed -i 's/baseUrl: '\''\//baseUrl: '\''\/${{ github.event.repository.name }}/' docusaurus.config.js
+          yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

Since we use docusaraus for turning markdown to html, it is often difficult to review docs changes without the creator including screenshots, or the reviewer downloading the code change and building the website locally.... NO MORE!

Now developers can use the `workflow_dispatch` function to build specific branches and deploy them to personal github pages.

![image](https://user-images.githubusercontent.com/11727736/210449780-5926a0a3-b326-4129-9e28-66ad9f423a14.png)

For example, my branch `can_test` is currently deployed to https://dereknola.github.io/docs-k3s/. Go check it out!