### PR TITLE
Document how to configure an HTTP proxy for K3s and Containerd

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -57,12 +57,12 @@ The K3s installation script will automatically take the `HTTP_PROXY`, `HTTPS_PRO
 
 Of course, you can also configure the proxy by editing these files.
 
-The `NO_PROXY` variable must include your internal networks, as well as the cluster pod and service IP ranges.
+K3s will automatically add the cluster internal Pod and Service IP ranges and cluster DNS domain to the list of `NO_PROXY` entries. You should ensure that the IP address ranges used by the Kubernetes nodes themselves (i.e. the public and private IPs of the nodes) are included in the `NO_PROXY` list, or that the nodes can be reached through the proxy.
 
 ```
 HTTP_PROXY=http://your-proxy.example.com:8888
 HTTPS_PROXY=http://your-proxy.example.com:8888
-NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ```
 
 If you want to configure the proxy settings for containerd without affecting K3s and the Kubelet, you can prefix the variables with `CONTAINERD_`:
@@ -70,7 +70,7 @@ If you want to configure the proxy settings for containerd without affecting K3s
 ```
 CONTAINERD_HTTP_PROXY=http://your-proxy.example.com:8888
 CONTAINERD_HTTPS_PROXY=http://your-proxy.example.com:8888
-CONTAINERD_NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+CONTAINERD_NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ```
 
 ## Using Docker as the Container Runtime

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -50,10 +50,12 @@ For information about deploying Helm charts, refer to the section about [Helm.](
 
 If you are running K3s in an environment, which only has external connectivity through an HTTP proxy, you can configure your proxy settings on the K3s systemd service. These proxy settings will then be used in K3s and passed down to the embedded containerd and kubelet.
 
-Add the necessary `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables to the environment file of your systemd service, usually:
+The K3s installation script will automatically take the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`, as well as `CONTAINERD_HTTP_PROXY`, `CONTAINERD_HTTPS_PROXY` and `CONTAINERD_NO_PROXY` variables from the current shell, if they are present, and write them to the environment file of your systemd service, usually:
 
-- `/etc/default/k3s`
-- `/etc/default/k3s-agent`
+- `/etc/systemd/system/k3s.service.env`
+- `/etc/systemd/system/k3s-agent.service.env`
+
+Of course, you can also configure the proxy by editing these files.
 
 The `NO_PROXY` variable must include your internal networks, as well as the cluster pod and service IP ranges.
 

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -46,6 +46,31 @@ Any file found in `/var/lib/rancher/k3s/server/manifests` will automatically be 
 
 For information about deploying Helm charts, refer to the section about [Helm.](../helm/helm.md)
 
+## Configuring an HTTP proxy
+
+If you are running K3s in an environment, which only has external connectivity through an HTTP proxy, you can configure your proxy settings on the K3s systemd service. These proxy settings will then be used in K3s and passed down to the embedded containerd and kubelet.
+
+Add the necessary `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables to the environment file of your systemd service, usually:
+
+- `/etc/default/k3s`
+- `/etc/default/k3s-agent`
+
+The `NO_PROXY` variable must include your internal networks, as well as the cluster pod and service IP ranges.
+
+```
+HTTP_PROXY=http://your-proxy.example.com:8888
+HTTPS_PROXY=http://your-proxy.example.com:8888
+NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+```
+
+If you want to configure the proxy settings for containerd without affecting K3s and the Kubelet, you can prefix the variables with `CONTAINERD_`:
+
+```
+CONTAINERD_HTTP_PROXY=http://your-proxy.example.com:8888
+CONTAINERD_HTTPS_PROXY=http://your-proxy.example.com:8888
+CONTAINERD_NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+```
+
 ## Using Docker as the Container Runtime
 
 K3s includes and defaults to [containerd](https://containerd.io/), an industry-standard container runtime.

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -50,7 +50,7 @@ For information about deploying Helm charts, refer to the section about [Helm.](
 
 If you are running K3s in an environment, which only has external connectivity through an HTTP proxy, you can configure your proxy settings on the K3s systemd service. These proxy settings will then be used in K3s and passed down to the embedded containerd and kubelet.
 
-The K3s installation script will automatically take the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`, as well as `CONTAINERD_HTTP_PROXY`, `CONTAINERD_HTTPS_PROXY` and `CONTAINERD_NO_PROXY` variables from the current shell, if they are present, and write them to the environment file of your systemd service, usually:
+The K3s installation script will automatically take the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`, as well as the `CONTAINERD_HTTP_PROXY`, `CONTAINERD_HTTPS_PROXY` and `CONTAINERD_NO_PROXY` variables from the current shell, if they are present, and write them to the environment file of your systemd service, usually:
 
 - `/etc/systemd/system/k3s.service.env`
 - `/etc/systemd/system/k3s-agent.service.env`


### PR DESCRIPTION
Similar documentation already exists for RKE2: https://docs.rke2.io/advanced#configuring-an-http-proxy