### PR TITLE
Add default tls-cipher-suites values

### DIFF
--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -655,6 +655,7 @@ kube-apiserver
     --storage-backend=etcd3 
     --tls-cert-file=/var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt        # 1.2.30
     --tls-private-key-file=/var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key # 1.2.30
+    --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 ```
 
 ```bash


### PR DESCRIPTION
This has always been the default set, we just didn't explicitly pass it to the apiserver.

Ref: https://github.com/k3s-io/k3s/pull/6725

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>