### PR TITLE
Clarify Networking Documentation

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -14,13 +14,7 @@ It also describes how agent nodes are registered with K3s servers.
 * An agent node is defined as a host running the `k3s agent` command, without any datastore or control-plane components.
 * Both servers and agents run the kubelet, container runtime, and CNI. See the [Advanced Options](../advanced/advanced.md#running-agentless-servers-experimental) documentation for more information on running agentless servers.
 
-This page covers the following topics:
-
-- [Single-server setup with an embedded database](#single-server-setup-with-an-embedded-db)
-- [High-availability K3s server with an external database](#high-availability-k3s-server-with-an-external-db)
-  - [Fixed registration address for agent nodes](#fixed-registration-address-for-agent-nodes)
-- [How agent node registration works](#how-agent-node-registration-works)
-- [Automatically deployed manifests](#automatically-deployed-manifests)
+![](/img/how-it-works-k3s-revised.svg)
 
 ### Single-server Setup with an Embedded DB
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -23,11 +23,17 @@ Please reference the K3s [BUILDING.md](https://github.com/k3s-io/k3s/blob/master
 
 ### Where are the K3s logs?
 
-The installation script will auto-detect if your OS is using systemd or openrc and start the service.
+The location of K3s logs will vary depending on how you run K3s and the node's OS.
 
 * When run from the command line, logs are sent to stdout and stderr.
 * When running under openrc, logs will be created at `/var/log/k3s.log`.
 * When running under Systemd, logs will be sent to Journald and can be viewed using `journalctl -u k3s`.
+* Pod logs can be found at `/var/log/pods`.
+* Containerd logs can be found at `/var/lib/rancher/k3s/agent/containerd/containerd.log`.
+
+You can generate more detailed logs by using the `--debug` flag when starting K3s (or `debug: true` in the configuration file).
+
+See [Additional Logging Sources](../advanced/advanced.md#additional-logging-sources) for even more log options.
 
 ### Can I run K3s in Docker?
 

--- a/docs/installation/network-options.md
+++ b/docs/installation/network-options.md
@@ -115,11 +115,24 @@ The egress selector mode may be configured on servers via the `--egress-selector
   **NOTE**: This will not work when using a CNI that uses its own IPAM and does not respect the node's PodCIDR allocation. `cluster` or `agent` should be used with these CNIs instead.
 * `cluster`: The apiserver uses agent tunnels to communicate with kubelets and service endpoints, routing endpoint connections to the correct agent by watching Endpoints.
 
-## Dual-stack installation
+## Dual-stack (IPv4 + IPv6) Networking
 
 :::info Version Gate
 
-Dual-stack networking is supported on K3s v1.21 and above.
+Experimental support is available as of [v1.21.0+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.21.0%2Bk3s1).  
+Stable support is available as of [v1.23.7+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.23.7%2Bk3s1). 
+
+:::
+
+:::caution Known Issue 
+
+Kubernetes v1.24 and v1.25 include [an issue](https://github.com/kubernetes/kubernetes/issues/111695) that ignores the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, add the following flag to both K3s servers and agents:
+
+```
+--kubelet-arg="node-ip=0.0.0.0" # To proritize IPv4 traffic
+#OR
+--kubelet-arg="node-ip=::" # To proritize IPv6 traffic
+```
 
 :::
 
@@ -135,21 +148,22 @@ Note that you may configure any valid `cluster-cidr` and `service-cidr` values, 
 
 If you are using a custom CNI plugin, i.e. a CNI plugin other than Flannel, the additional configuration may be required. Please consult your plugin's dual-stack documentation and verify if network policies can be enabled.
 
-> **Warning:** Kubernetes 1.24 and 1.25 include a bug that ignores the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, add the following flag to both K3s servers and agents:
-
-```
---kubelet-arg=node-ip=0.0.0.0"  # If you want to prioritize IPv6 traffic, use "::" instead of "0.0.0.0".
-```
-
-## Single-stack IPv6 installation
+## Single-stack IPv6 Networking
 
 :::info Version Gate
-
-Single-stack IPv6 clusters (clusters without IPv4) are supported on K3s v1.22 and above.
-
+Available as of [v1.22.9+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.22.9%2Bk3s1)
 :::
 
-> **Warning:** If your IPv6 default route is set by a router advertisement (RA), you will need to set the sysctl `net.ipv6.conf.all.accept_ra=2`; otherwise, the node will drop the default route once it expires. Be aware that accepting RAs could increase the risk of [man-in-the-middle attacks](https://github.com/kubernetes/kubernetes/issues/91507).
+:::caution Known Issue
+If your IPv6 default route is set by a router advertisement (RA), you will need to set the sysctl `net.ipv6.conf.all.accept_ra=2`; otherwise, the node will drop the default route once it expires. Be aware that accepting RAs could increase the risk of [man-in-the-middle attacks](https://github.com/kubernetes/kubernetes/issues/91507).
+:::
+
+Single-stack IPv6 clusters (clusters without IPv4) are supported on K3s using the `--cluster-cidr` and `--service-cidr` flags. This is an example of a valid configuration:
+
+```bash
+--cluster-cidr=2001:cafe:42:0::/56 --service-cidr=2001:cafe:42:1::/112
+```
+
 
 ## Distributed hybrid or multicloud cluster
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -25,7 +25,7 @@ The Traefik ingress controller will use ports 80 and 443 on the host (i.e. these
 
 The `traefik.yaml` file should not be edited manually, because k3s would overwrite it again once it is restarted. Instead you can customize Traefik by creating an additional `HelmChartConfig` manifest in `/var/lib/rancher/k3s/server/manifests`. For more details and an example see [Customizing Packaged Components with HelmChartConfig](../helm/helm.md#customizing-packaged-components-with-helmchartconfig). For more information on the possible configuration values, refer to the official [Traefik Helm Configuration Parameters.](https://github.com/traefik/traefik-helm-chart/tree/master/traefik).
 
-To disable it, start each server with the `--disable traefik` flag.
+To disable it, start each server with the `--disable=traefik` flag.
 
 If Traefik is not disabled K3s versions 1.20 and earlier will install Traefik v1, while K3s versions 1.21 and later will install Traefik v2 if v1 is not already present.
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -85,13 +85,16 @@ This is necessary if you wish to run a different LB, such as MetalLB.
 
 ## External Cloud Controller Manager
 
-K3s does not ship with any "in-tree" cloud providers. Instead, K3s ships with a Cloud Controller Manager (CCM) stub that does the following:
+In order to reduce binary size, K3s removes all "in-tree" (built-in) cloud providers. Instead, K3s provides an embedded Cloud Controller Manager (CCM) stub that does the following:
 - Sets node InternalIP and ExternalIP address fields based on the `--node-ip` and `--node-external-ip` flags.
 - Hosts the ServiceLB LoadBalancer controller.
 - Clears the `node.cloudprovider.kubernetes.io/uninitialized` taint that is present when the cloud-provider is set to `external` 
 
-In order to use an external CCM, you must start K3s with the `--disable-cloud-controller` flag. Additionally, if you disable the built-in CCM and do not provide an external CCM, nodes will remain tainted and unschedulable.
+Before deploying an external CCM, you must start all K3s servers with the `--disable-cloud-controller` flag to disable to embedded CCM. 
 
+:::note
+If you disable the built-in CCM and do not deploy and properly configure an external substitute, nodes will remain tainted and unschedulable.
+:::
 
 ## Nodes Without a Hostname
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -25,7 +25,7 @@ The Traefik ingress controller will use ports 80 and 443 on the host (i.e. these
 
 The `traefik.yaml` file should not be edited manually, because k3s would overwrite it again once it is restarted. Instead you can customize Traefik by creating an additional `HelmChartConfig` manifest in `/var/lib/rancher/k3s/server/manifests`. For more details and an example see [Customizing Packaged Components with HelmChartConfig](../helm/helm.md#customizing-packaged-components-with-helmchartconfig). For more information on the possible configuration values, refer to the official [Traefik Helm Configuration Parameters.](https://github.com/traefik/traefik-helm-chart/tree/master/traefik).
 
-To disable it, start each server with the `--disable traefik` option.
+To disable it, start each server with the `--disable traefik` flag.
 
 If Traefik is not disabled K3s versions 1.20 and earlier will install Traefik v1, while K3s versions 1.21 and later will install Traefik v2 if v1 is not already present.
 
@@ -79,17 +79,19 @@ To select a particular subset of nodes to host pods for a LoadBalancer, set matc
 
 ### Disabling the Service LB
 
-To disable the embedded LB, configure all servers in the cluster with the `--disable=servicelb` option.
+To disable the embedded LB, configure all servers in the cluster with the `--disable=servicelb` flag.
 
 This is necessary if you wish to run a different LB, such as MetalLB.
 
 ## External Cloud Controller Manager
 
-K3s ships with a stub Cloud Controller Manager (CCM) that does not actually implement any functionality. In order to use an external CCM, you must start K3s with the `--disable-cloud-controller` flag. 
+K3s does not ship with any "in-tree" cloud providers. Instead, K3s ships with a Cloud Controller Manager (CCM) stub that does the following:
+- Sets node InternalIP and ExternalIP address fields based on the `--node-ip` and `--node-external-ip` flags.
+- Hosts the ServiceLB LoadBalancer controller.
+- Clears the `node.cloudprovider.kubernetes.io/uninitialized` taint that is present when the cloud-provider is set to `external` 
 
-:::note K3s v1.22 and older
-In order to deploy an external CCM with K3s v1.22 and older, you must also start K3s with the `--kubelet-arg="cloud-provider=external"` flag.
-:::
+In order to use an external CCM, you must start K3s with the `--disable-cloud-controller` flag. Additionally, if you disable the built-in CCM and do not provide an external CCM, nodes will remain tainted and unschedulable.
+
 
 ## Nodes Without a Hostname
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -31,6 +31,13 @@ If Traefik is not disabled K3s versions 1.20 and earlier will install Traefik v1
 
 To migrate from an older Traefik v1 instance please refer to the [Traefik documentation](https://doc.traefik.io/traefik/migration/v1-to-v2/) and [migration tool](https://github.com/traefik/traefik-migration-tool).
 
+
+## Network Policy Controller
+
+K3s includes an embedded network policy controller. The underlying implementation is [kube-router's](https://github.com/cloudnativelabs/kube-router) netpol controller library (no other kube-router functionality is present) and can be found [here](https://github.com/k3s-io/k3s/tree/master/pkg/agent/netpol). 
+
+To disable it, start each server with the `--disable-network-policy` flag.
+
 ## Service Load Balancer
 
 Any service load balancer (LB) can be used in your K3s cluster. By default, K3s provides a load balancer known as [ServiceLB](https://github.com/k3s-io/klipper-lb) (formerly Klipper Load Balancer) that uses available host ports.
@@ -75,6 +82,14 @@ To select a particular subset of nodes to host pods for a LoadBalancer, set matc
 To disable the embedded LB, configure all servers in the cluster with the `--disable=servicelb` option.
 
 This is necessary if you wish to run a different LB, such as MetalLB.
+
+## External Cloud Controller Manager
+
+K3s ships with a stub Cloud Controller Manager (CCM) that does not actually implement any functionality. In order to use an external CCM, you must start K3s with the `--disable-cloud-controller` flag. 
+
+:::note K3s v1.22 and older
+In order to deploy an external CCM with K3s v1.22 and older, you must also start K3s with the `--kubelet-arg="cloud-provider=external"` flag.
+:::
 
 ## Nodes Without a Hostname
 

--- a/docs/quick-start/quick-start.md
+++ b/docs/quick-start/quick-start.md
@@ -7,7 +7,7 @@ This guide will help you quickly launch a cluster with default options. The [ins
 
 For information on how K3s components work together, refer to the [architecture section.](../architecture/architecture.md)
 
-:::note
+:::info
 New to Kubernetes? The official Kubernetes docs already have some great tutorials outlining the basics [here](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 :::
 


### PR DESCRIPTION
Addresses:
- https://github.com/k3s-io/k3s/issues/1049
- https://github.com/k3s-io/k3s/issues/1310
- https://github.com/k3s-io/k3s/issues/1308
- https://github.com/k3s-io/docs/issues/97

Other Changes:
- Clarifies which versions added dual-stack and ipv6 only support.
- Adds more information about how to get logs. 