### PR TITLE
More docs backlog fixes

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -49,6 +49,13 @@ In K3s, there are two types of tokens: `K3S_TOKEN` and `K3S_AGENT_TOKEN`.
 
 If no `K3S_TOKEN` is defined, the first K3s server will generate a random token during initial startup. The result is part of the content in `/var/lib/rancher/k3s/server/token`. For example, `K1070878408e06a827960208f84ed18b65fa10f27864e71a57d9e053c4caff8504b::server:df54383b5659b9280aa1e73e60ef78fc`. The token in this example is `df54383b5659b9280aa1e73e60ef78fc`. The full format with the `K10` prefix includes a hash of the cluster's CA certificate, which can be used to ensure that nodes are joining the correct cluster and are not subject to a man-in-the-middle attack during the join process. This full token cannot be generated prior to initial cluster startup, before the cluster CA has been generated.
 
+
+### How compatible are different versions of K3s?
+
+In general, the [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) applies.
+
+In short, servers can be newer than agents, but agents cannot be newer than servers.
+
 ### I'm having an issue, where can I get help?
  
 If you are having an issue with deploying K3s, you should:
@@ -57,7 +64,7 @@ If you are having an issue with deploying K3s, you should:
 
 2) Check that you have resolved any [Additional OS Preparation](../advanced/advanced.md#additional-os-preparations). Run `k3s check-config` and ensure that it passes.
 
-3) Search the [K3s GitHub existing issues](https://github.com/k3s-io/k3s/issues) for one that matches your problem.
+3) Search the K3s [Issues](https://github.com/k3s-io/k3s/issues) and [Discussions](https://github.com/k3s-io/k3s/discussions) for one that matches your problem.
 
 4) Join the [Rancher Slack](https://slack.rancher.io/) K3s channel to get help.
 

--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -35,9 +35,7 @@ sudo mkdir -p /var/lib/rancher/k3s/agent/images/
 sudo cp ./k3s-airgap-images-$ARCH.tar /var/lib/rancher/k3s/agent/images/
 ```
 
-Place the k3s binary at `/usr/local/bin/k3s` and ensure it is executable.
-
-Follow the steps in the next section to install K3s.
+Once you have completed this, you may now go to the [Install K3s](#install-k3s) section below.
 
 ## Install K3s
 
@@ -63,11 +61,15 @@ To install K3s on a single server, simply do the following on the server node:
 INSTALL_K3S_SKIP_DOWNLOAD=true ./install.sh
 ```
 
-Then, to optionally add additional agents do the following on each agent node. Take care to ensure you replace `myserver` with the IP or valid DNS of the server and replace `mynodetoken` with the node token from the server typically at `/var/lib/rancher/k3s/server/node-token`
+To add additional agents, do the following on each agent node: 
 
 ```bash
-INSTALL_K3S_SKIP_DOWNLOAD=true K3S_URL=https://myserver:6443 K3S_TOKEN=mynodetoken ./install.sh
+INSTALL_K3S_SKIP_DOWNLOAD=true K3S_URL=https://<SERVER_IP>:6443 K3S_TOKEN=<YOUR_TOKEN> ./install.sh
 ```
+
+:::note
+The token from the server is typically found at `/var/lib/rancher/k3s/server/token`.
+:::
 
 </TabItem>
 <TabItem value="High Availability Configuration" default>
@@ -78,19 +80,24 @@ For example, step two of the High Availability with an External DB guide mention
 
 ```bash
 curl -sfL https://get.k3s.io | sh -s - server \
-  --datastore-endpoint='mysql://username:password@tcp(hostname:3306)/database-name'
+  --token=SECRET \
+  --datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
 ```
 
 Instead, you would modify such examples like below:
 
 ```bash
-INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_EXEC='server' K3S_DATASTORE_ENDPOINT='mysql://username:password@tcp(hostname:3306)/database-name' ./install.sh
+INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_EXEC='server --token=SECRET' \
+K3S_DATASTORE_ENDPOINT='mysql://username:password@tcp(hostname:3306)/database-name' \
+./install.sh
 ```
 
 </TabItem>
 </Tabs>
 
->**Note:** K3s additionally provides a `--resolv-conf` flag for kubelets, which may help with configuring DNS in air-gap networks.
+:::note
+K3s additionally provides a `--resolv-conf` flag for kubelets, which may help with configuring DNS in air-gap networks.
+:::
 
 ## Upgrading
 

--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -44,7 +44,7 @@ Once you have completed this, you may now go to the [Install K3s](#install-k3s) 
 - Before installing K3s, complete the [Private Registry Method](#private-registry-method) or the [Manually Deploy Images Method](#manually-deploy-images-method) above to prepopulate the images that K3s needs to install.
 - Download the K3s binary from the [releases](https://github.com/k3s-io/k3s/releases) page, matching the same version used to get the airgap images. Place the binary in `/usr/local/bin` on each air-gapped node and ensure it is executable.
 - Download the K3s install script at [get.k3s.io](https://get.k3s.io). Place the install script anywhere on each air-gapped node, and name it `install.sh`.
-- K3s requires a default route to start. Therefore, a default route must be configured on each node, even if that route is a dummy route or a black hole.
+- K3s requires a default route in order to auto-detect the node's primary IP, and for kube-proxy ClusterIP routing to function properly. Therefore, a default route must be configured on each node, even if that route is a dummy route or a black hole.
 
 When running the K3s script with the `INSTALL_K3S_SKIP_DOWNLOAD` environment variable, K3s will use the local version of the script and binary.
 

--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -44,6 +44,7 @@ Once you have completed this, you may now go to the [Install K3s](#install-k3s) 
 - Before installing K3s, complete the [Private Registry Method](#private-registry-method) or the [Manually Deploy Images Method](#manually-deploy-images-method) above to prepopulate the images that K3s needs to install.
 - Download the K3s binary from the [releases](https://github.com/k3s-io/k3s/releases) page, matching the same version used to get the airgap images. Place the binary in `/usr/local/bin` on each air-gapped node and ensure it is executable.
 - Download the K3s install script at [get.k3s.io](https://get.k3s.io). Place the install script anywhere on each air-gapped node, and name it `install.sh`.
+- K3s requires a default route to start. Therefore, a default route must be configured on each node, even if that route is a dummy route or a black hole.
 
 When running the K3s script with the `INSTALL_K3S_SKIP_DOWNLOAD` environment variable, K3s will use the local version of the script and binary.
 

--- a/docs/installation/private-registry.md
+++ b/docs/installation/private-registry.md
@@ -33,6 +33,21 @@ mirrors:
 
 Each mirror must have a name and set of endpoints. When pulling an image from a registry, containerd will try these endpoint URLs one by one, and use the first working one.
 
+#### Redirects
+
+If a public registry is used as a mirror, such as when configuring a [pull through cache](https://docs.docker.com/registry/recipes/mirror/), images pulls are transparently redirected.
+
+For example, if you have a mirror configured for `docker.io`:
+
+```yaml
+mirrors:
+  docker.io:
+    endpoint:
+      - "https://mycustomreg.com:5000"
+```
+
+Then pulling `docker.io/rancher/coredns-coredns:1.6.3` will transparently pull the image from `https://mycustomreg.com:5000/rancher/coredns-coredns:1.6.3`.
+
 #### Rewrites
 
 Each mirror can have a set of rewrites. Rewrites can change the tag of an image based on a regular expression. This is useful if the organization/project structure in the mirror registry is different to the upstream one.
@@ -151,7 +166,7 @@ In order for the registry changes to take effect, you need to restart K3s on eac
 
 ## Adding Images to the Private Registry
 
-First, obtain the k3s-images.txt file from GitHub for the release you are working with.
+First, obtain the `k3s-images.txt` file from GitHub for the release you are working with.
 Pull the K3s images listed on the k3s-images.txt file from docker.io
 
 Example: `docker pull docker.io/rancher/coredns-coredns:1.6.3`

--- a/docs/upgrades/automated.md
+++ b/docs/upgrades/automated.md
@@ -35,6 +35,9 @@ For more details on the design and architecture of the system-upgrade-controller
 - [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller)
 - [k3s-upgrade](https://github.com/k3s-io/k3s-upgrade)
 
+:::info 
+When attempting to run different versions of K3s in a cluster, the [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) applies.
+:::
 
 ### Install the system-upgrade-controller
  The system-upgrade-controller can be installed as a deployment into your cluster. The deployment requires a service-account, clusterRoleBinding, and a configmap. To install these components, run the following command:

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -21,6 +21,10 @@ Upgrades performed via the installation script or using our [automated upgrades]
 
 For an exhaustive and up-to-date list of channels, you can visit the [k3s channel service API](https://update.k3s.io/v1-release/channels). For more technical details on how channels work, you see the [channelserver project](https://github.com/rancher/channelserver).
 
+:::info 
+When attempting to run different versions of K3s in a cluster, the [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) applies.
+:::
+
 ### Upgrade K3s Using the Installation Script
 
 To upgrade K3s from an older version you can re-run the installation script using the same flags, for example:


### PR DESCRIPTION
## Addresses lingering issue from:
- https://github.com/k3s-io/k3s/issues/1802
- https://github.com/k3s-io/k3s/issues/1148
- https://github.com/k3s-io/k3s/issues/1103
- https://github.com/k3s-io/k3s/issues/3217

## Changes:
- Most of the questions around private registry use has already been resolved. I simply added additional clarification around public->private image redirection. 
- I cleaned up some bad wording around air-gap installs. Some steps were duplicated (such as install the k3s binary twice).
- Added note on K3s needing a default route, even in an air-gapped environment 
- Add FAQ about compatibility between different K3s versions. 