### PR TITLE
Fixed Typo in Configuration.md

### DIFF
--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -26,7 +26,7 @@ When registering an agent, the following commands all result in the same behavio
 
 ```bash
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --server https://k3s.example.com --token mypassword" sh -s -
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3s_TOKEN="mypassword" sh -s - --server https://k3s.example.com
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3S_TOKEN="mypassword" sh -s - --server https://k3s.example.com
 curl -sfL https://get.k3s.io | K3S_URL=https://k3s.example.com sh -s - agent --token mypassword
 curl -sfL https://get.k3s.io | K3S_URL=https://k3s.example.com K3S_TOKEN=mypassword sh -s - # agent is assumed because of K3S_URL
 ```


### PR DESCRIPTION
In the second line of  bash block  behind "When registering an agent, the following commands all result in the same behavior" was "K3s_TOKEN" instead of "K3S_TOKEN"