### PR TITLE
Fix flag for disabling servicelb

### DIFF
--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -22,7 +22,7 @@ The following options must be set to the same value on all servers in the cluste
 * `--disable-cloud-controller`
 * `--disable-helm-controller`
 * `--disable-network-policy`
-* `--disable-servicelb`
+* `--disable servicelb`
 * `--egress-selector-mode`
 * `--flannel-backend`
 * `--flannel-external-ip`

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -22,7 +22,7 @@ The following options must be set to the same value on all servers in the cluste
 * `--disable-cloud-controller`
 * `--disable-helm-controller`
 * `--disable-network-policy`
-* `--disable servicelb`
+* `--disable=servicelb` *note: other packaged components may be disabled on a per-server basis*
 * `--egress-selector-mode`
 * `--flannel-backend`
 * `--flannel-external-ip`


### PR DESCRIPTION
There is no `--disable-servicelb` flag. Instead, ServiceLB is disabled with the `--disable servicelb` flag and argument.

See [Using the `--disable` flag][1], **K3s Server CLI Help** at the bottom of the [`server` CLI page][2], and the [source code for the `server` flags][3].

[1]: https://docs.k3s.io/installation/packaged-components#using-the---disable-flag
[2]: https://docs.k3s.io/cli/server
[3]: https://github.com/k3s-io/k3s/blob/master/pkg/cli/cmds/server.go#L437