### PR TITLE
Update Resource Profiling to v1.26

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -46,6 +46,10 @@ Hardware requirements scale based on the size of your deployments. Minimum recom
 
 [Resource Profiling](../reference/resource-profiling.md) captures the results of tests to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent. It also contains analysis about what has the biggest impact on K3s server and agent utilization, and how the cluster datastore can be protected from interference from agents and workloads.
 
+:::info Raspberry Pi and embedded etcd
+If deploying K3s with embedded etcd on a Raspberry Pi, it is recommended that you use an external SSD. etcd is write intensive, and SD cards cannot handle the IO load.
+:::
+
 #### Disks
 
 K3s performance depends on the performance of the database. To ensure optimal speed, we recommend using an SSD when possible. Disk performance will vary on ARM devices utilizing an SD card or eMMC.

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -21,8 +21,11 @@ K3s is available for the following architectures:
 - arm64/aarch64
 - s390x
 
-On `aarch64/arm64` systems, the OS must use a 4k page size. **RHEL9**, **Ubuntu**, and **SLES** all meet this requirement.
+:::caution ARM64 Page Size
 
+Prior to May 2023 releases (v1.24.14+k3s1, v1.25.10+k3s1, v1.26.5+k3s1, v1.27.2+k3s1), on `aarch64/arm64` systems, the OS must use a 4k page size. **RHEL9**, **Ubuntu**, **Raspberry PI OS**, and **SLES** all meet this requirement.
+
+:::
 
 ## Operating Systems
 

--- a/docs/reference/resource-profiling.md
+++ b/docs/reference/resource-profiling.md
@@ -9,12 +9,12 @@ The results are summarized as follows:
 
 | Components |  Processor | Min CPU | Min RAM with Kine/SQLite | Min RAM with Embedded etcd |
 |------------|-----|----------|-------------------------|---------------------------|
-| K3s server with a workload  | Intel(R) Xeon(R) Platinum 8124M CPU, 3.00 GHz | 10% of a core | 768 M | 896 M |
-| K3s cluster with a single agent  | Intel(R) Xeon(R) Platinum 8124M CPU, 3.00 GHz | 10% of a core | 512 M | 768 M |
-| K3s agent | Intel(R) Xeon(R) Platinum 8124M CPU, 3.00 GHz | 5% of a core | 256 M | 256 M |
-| K3s server with a workload  | Pi4B BCM2711, 1.50 GHz | 20% of a core | 768 M | 896 M |
-| K3s cluster with a single agent | Pi4B BCM2711, 1.50 GHz | 20% of a core | 512 M | 768 M |
-| K3s agent  | Pi4B BCM2711, 1.50 GHz | 10% of a core | 256 M | 256 M |
+| K3s server with a workload  | Intel 8375C CPU, 2.90 GHz | 6% of a core | 1602 M | 1604 M |
+| K3s cluster with a single agent  | Intel 8375C CPU, 2.90 GHz | 5% of a core | 1428 M | 1450 M |
+| K3s agent | Intel 8375C CPU, 2.90 GHz | 3% of a core | 275 M | 275 M |
+| K3s server with a workload  | Pi4B BCM2711, 1.50 GHz | 30% of a core | 1588 M | 1613 M |
+| K3s cluster with a single agent | Pi4B BCM2711, 1.50 GHz | 25% of a core | 1215 M | 1413 M |
+| K3s agent  | Pi4B BCM2711, 1.50 GHz | 10% of a core | 268 M | 268 M |
 
 - [Scope of Resource Testing](#scope-of-resource-testing)
 - [Components Included for Baseline Measurements](#components-included-for-baseline-measurements)
@@ -62,7 +62,7 @@ Utilization figures were based on 95th percentile readings from steady state ope
 | Arch | OS | System | CPU | RAM | Disk | 
 |------|----|--------|--|----|------|
 | x86_64 | Ubuntu 22.04 | AWS c6id.xlarge | Intel 8375C CPU, 4 Core 2.90 GHz | 8 GB | NVME SSD |
-| aarch64 | Raspbian Linux 11 | Raspberry Pi 4 Model B | BCM2711, 4 Core 1.50 GHz | 8 GB | UHS-III SDXC |
+| aarch64 | Raspberry Pi OS 11 | Raspberry Pi 4 Model B | BCM2711, 4 Core 1.50 GHz | 8 GB | UHS-III SDXC |
 
 
 ## Baseline Resource Requirements
@@ -71,7 +71,7 @@ This section captures the results of tests to determine minimum resource require
 
 ### K3s Server with a Workload
 
-These are the requirements for a single-node cluster in which the K3s server shares resources with a simple workload.
+These are the requirements for a single-node cluster in which the K3s server shares resources with a [simple workload](https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/).
 
 The CPU requirements are:
 
@@ -81,6 +81,7 @@ The CPU requirements are:
 | Pi4B | 30% of a core |
 
 The Memory Requirements are:
+
 | Tested Datastore | System | Memory |
 |-----------|---------|------|
 | Kine/SQLite | c6id.xlarge | 1602 M | 
@@ -105,15 +106,16 @@ The CPU requirements are:
 | System | CPU Core Usage | 
 |--------|----------------|
 | c6id.xlarge | 5% of a core |
-| Pi4B | 30% of a core |
+| Pi4B | 25% of a core |
 
 The Memory Requirements are:
+
 | Tested Datastore | System | Memory |
 |-----------|---------|------|
-| Kine/SQLite | Pi4B |  1215 M |
-|             | c6id.xlarge | 1428 M | 
-| Embedded etcd | Pi4B |  1413 M |
-|               | c6id.xlarge | 1450 M | 
+| Kine/SQLite | c6id.xlarge | 1428 M |
+|             | Pi4B |  1215 M |
+| Embedded etcd | c6id.xlarge | 1450 M |
+|               | Pi4B |  1413 M |
 
 ### K3s Agent
 

--- a/docs/reference/resource-profiling.md
+++ b/docs/reference/resource-profiling.md
@@ -61,7 +61,7 @@ Utilization figures were based on 95th percentile readings from steady state ope
 
 | Arch | OS | System | CPU | RAM | Disk | 
 |------|----|--------|--|----|------|
-| x86_64 | Ubuntu 22.04 | AWS c6id.xlarge | Intel 8375C CPU, 4 Core 2.90 GHz | 8 GB | NVME SSD |
+| x86_64 | Ubuntu 22.04 | AWS c6id.xlarge | Intel Xeon Platinum 8375C CPU, 4 Core 2.90 GHz | 8 GB | NVME SSD |
 | aarch64 | Raspberry Pi OS 11 | Raspberry Pi 4 Model B | BCM2711, 4 Core 1.50 GHz | 8 GB | UHS-III SDXC |
 
 
@@ -77,16 +77,16 @@ The CPU requirements are:
 
 | System | CPU Core Usage |
 |--------|----------------|
-| c6id.xlarge | 6% of a core |
+| Intel 8375C | 6% of a core |
 | Pi4B | 30% of a core |
 
 The Memory Requirements are:
 
 | Tested Datastore | System | Memory |
 |-----------|---------|------|
-| Kine/SQLite | c6id.xlarge | 1602 M | 
+| Kine/SQLite | Intel 8375C | 1602 M | 
 |             | Pi4B |  1588 M |
-| Embedded etcd | c6id.xlarge | 1604 M | 
+| Embedded etcd | Intel 8375C | 1604 M | 
 |               | Pi4B |  1613 M |
 
 The Disk requirements are:
@@ -105,16 +105,16 @@ The CPU requirements are:
 
 | System | CPU Core Usage | 
 |--------|----------------|
-| c6id.xlarge | 5% of a core |
+| Intel 8375C | 5% of a core |
 | Pi4B | 25% of a core |
 
 The Memory Requirements are:
 
 | Tested Datastore | System | Memory |
 |-----------|---------|------|
-| Kine/SQLite | c6id.xlarge | 1428 M |
+| Kine/SQLite | Intel 8375C | 1428 M |
 |             | Pi4B |  1215 M |
-| Embedded etcd | c6id.xlarge | 1450 M |
+| Embedded etcd | Intel 8375C | 1450 M |
 |               | Pi4B |  1413 M |
 
 ### K3s Agent
@@ -123,7 +123,7 @@ The requirements are:
 
 | System | CPU Core Usage | RAM |
 |--------|----------------|-----|
-| c6id.xlarge | 3% of a core | 275 M |
+| Intel 8375C | 3% of a core | 275 M |
 | Pi4B | 5% of a core | 268 M |
 
 

--- a/docs/reference/resource-profiling.md
+++ b/docs/reference/resource-profiling.md
@@ -9,7 +9,7 @@ The results are summarized as follows:
 
 | Components |  Processor | Min CPU | Min RAM with Kine/SQLite | Min RAM with Embedded etcd |
 |------------|-----|----------|-------------------------|---------------------------|
-| K3s server with a workload  | Intel 8375C CPU, 2.90 GHz | 6% of a core | 1602 M | 1604 M |
+| K3s server with a workload  | Intel 8375C CPU, 2.90 GHz | 6% of a core | 1596 M | 1606 M |
 | K3s cluster with a single agent  | Intel 8375C CPU, 2.90 GHz | 5% of a core | 1428 M | 1450 M |
 | K3s agent | Intel 8375C CPU, 2.90 GHz | 3% of a core | 275 M | 275 M |
 | K3s server with a workload  | Pi4B BCM2711, 1.50 GHz | 30% of a core | 1588 M | 1613 M |
@@ -84,9 +84,9 @@ The Memory Requirements are:
 
 | Tested Datastore | System | Memory |
 |-----------|---------|------|
-| Kine/SQLite | Intel 8375C | 1602 M | 
+| Kine/SQLite | Intel 8375C | 1596 M | 
 |             | Pi4B |  1588 M |
-| Embedded etcd | Intel 8375C | 1604 M | 
+| Embedded etcd | Intel 8375C | 1606 M | 
 |               | Pi4B |  1613 M |
 
 The Disk requirements are:


### PR DESCRIPTION
- Testing K3s resources requirements with update K3s version and new AWS instances (C6 is now cheaper/better than C5). Addresses https://github.com/k3s-io/k3s/issues/3976
- Updated ARM 4K page requirement to indicate new versions don't need it. Addresses: https://github.com/k3s-io/docs/issues/137
- Add note about SSDs on Raspberry PIs