### PR TITLE
Change <NAMESPACE> to kube-system

### DIFF
--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -395,7 +395,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-network-dns-policy
-  namespace: <NAMESPACE>
+  namespace: kube-system
 spec:
   ingress:
   - ports:


### PR DESCRIPTION
Hello!
I'm not sure why in the hardening docs there is a namespace named `<NAMESPACE>`.
After reading the doc, I think `kube-system` should be used as an example instead of  `<NAMESPACE>`.