### PR TITLE
Update datastore.md

### DIFF
--- a/docs/datastore/datastore.md
+++ b/docs/datastore/datastore.md
@@ -27,7 +27,7 @@ K3s supports the following datastore options:
   * [PostgreSQL](https://www.postgresql.org/) (certified against versions 10.7, 11.5, and 14.2)
 
 :::caution Prepared Statement Support
-K3s requires prepared statements support from the DB. This means that connection poolers such as [PgBouncer](https://www.pgbouncer.org/faq.html#how-to-use-prepared-statements-with-transaction-pooling) will not work with K3s.
+K3s requires prepared statements support from the DB. This means that connection poolers such as [PgBouncer](https://www.pgbouncer.org/faq.html#how-to-use-prepared-statements-with-transaction-pooling) may require additional configuration to work with K3s.
 :::
 
 ### External Datastore Configuration Parameters


### PR DESCRIPTION
PgBouncer ~will~ supports protocol-level named prepared statements in v1.21.0.

Another connection pooler PgCat added support in v1.1. https://github.com/postgresml/pgcat/releases/tag/v1.1.0