### PR TITLE
Networking content update

### DIFF
--- a/docs/installation/network-options.md
+++ b/docs/installation/network-options.md
@@ -27,7 +27,6 @@ This page describes K3s network configuration options, including configuration o
  `--flannel-backend=host-gw` | Use IP routes to pod subnets via node IPs. Requires direct layer 2 connectivity between all nodes in the cluster. |
  `--flannel-backend=wireguard-native` | Use WireGuard to encapsulate and encrypt network traffic. May require additional kernel modules. |
  `--flannel-backend=ipsec` | Use strongSwan IPSec via the `swanctl` binary to encrypt network traffic. (Deprecated; will be removed in v1.27.0) |
- `--flannel-backend=wireguard` | Use WireGuard via the `wg` binary to encrypt network traffic. May require additional kernel modules and configuration. (Deprecated; will be removed in v1.26.0) |
  `--flannel-backend=none` | Disable Flannel entirely. |
 
 :::info Version Gate
@@ -36,7 +35,7 @@ K3s no longer includes strongSwan `swanctl` and `charon` binaries starting with 
 
 :::
 
-### Migrating from `wireguard` or `ipsec` to `wireguard-native`
+#### Migrating from `wireguard` or `ipsec` to `wireguard-native`
 
 The legacy `wireguard` backend requires installation of the `wg` tool on the host. This backend will be removed in K3s v1.26, in favor of `wireguard-native` backend, which directly interfaces with the kernel.
 
@@ -141,7 +140,7 @@ Stable support is available as of [v1.23.7+k3s1](https://github.com/k3s-io/k3s/r
 
 :::caution Known Issue 
 
-Kubernetes [Issue #111695](https://github.com/kubernetes/kubernetes/issues/111695) causes the Kubelet to ignore the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, add the following flag to both K3s servers and agents:
+Before 1.27, Kubernetes [Issue #111695](https://github.com/kubernetes/kubernetes/issues/111695) causes the Kubelet to ignore the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, use 1.27 or newer or add the following flag to both K3s servers and agents:
 
 ```
 --kubelet-arg="node-ip=0.0.0.0" # To proritize IPv4 traffic
@@ -162,6 +161,10 @@ To enable dual-stack in K3s, you must provide valid dual-stack `cluster-cidr` an
 Note that you may configure any valid `cluster-cidr` and `service-cidr` values, but the above masks are recommended. If you change the `cluster-cidr` mask, you should also change the `node-cidr-mask-size-ipv4` and `node-cidr-mask-size-ipv6` values to match the planned pods per node and total node count. The largest supported `service-cidr` mask is /12 for IPv4, and /112 for IPv6. Remember to allow ipv6 traffic if you are deploying in a public cloud.
 
 If you are using a custom CNI plugin, i.e. a CNI plugin other than Flannel, the additional configuration may be required. Please consult your plugin's dual-stack documentation and verify if network policies can be enabled.
+
+:::caution Known Issue
+When defining cluster-cidr and service-cidr with IPv6 as the primary family, the node-ip of all cluster members should be explicitly set, placing node's desired IPv6 address as the first address. By default, the kubelet always uses IPv4 as the primary address family.
+:::
 
 ## Single-stack IPv6 Networking
 

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -3,7 +3,7 @@ title: "Networking"
 weight: 35
 ---
 
-This page explains how CoreDNS, the Traefik Ingress controller, and Klipper service load balancer work within K3s.
+This page explains how CoreDNS, Traefik Ingress controller, Network Policy controller, and ServiceLB load balancer controller work within K3s.
 
 Refer to the [Installation Network Options](../installation/network-options.md) page for details on Flannel configuration options and backend selection, or how to set up your own CNI.
 
@@ -107,48 +107,3 @@ If you disable the built-in CCM and do not deploy and properly configure an exte
 ## Nodes Without a Hostname
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run K3s with the `--node-name` flag or `K3S_NODE_NAME` environment variable and this will pass the node name to resolve this issue.
-
-## Multicluster CIDR (Experimental)
-
-:::info Version Gate
-
-Experimental as of v1.26.3+k3s1
-
-:::
-
-:::caution Warning
-The network policy controller could not work properly when this flag is enabled.
-:::
-
-From `v1.26` Kubernetes introduced Multicluster CIDR as an alpha feature. (https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2593-multiple-cluster-cidrs)
-
-This feature can be enabled on K3s server with the `--multi-cluster-cidr` flag and it gives the possibility to define multiple cluster CIDR used to allocate the podCIDR for each node with also the possibility to extend it on an already running cluster.
-The `clustercidr` resources will be visible through the API and `kubectl` (the CIDR configured with `--cluster-cidr` is defined as the default one).
-
-A new `clustercidr` can be defined as follow:
-
-```
-apiVersion: networking.k8s.io/v1alpha1
-kind: ClusterCIDR
-metadata:
-  name: new-cidr
-spec:
-  nodeSelector:
-    nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-          -  "worker2"
-  perNodeHostBits: 8
-  ipv4: 10.247.0.0/16
-```
-
-The nodes that match the `nodeSelector` will use a podCIDR from the new defined resource.
-
-:::note
-A node that already has a CIDR cannot get a new one. It has to be removed and restarted.
-:::
-:::caution Warning
-A dualstack CIDR could be defined with both `ipv4` and `ipv6` configuration but the `perNodeHostBits` will be the same. When a dualstack configuration is defined with `--cluster-cidr` the `--node-cidr-mask-size-ipv6` flag on the `kube-controller` should be defined to have the same size of IPv4.
-:::

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -131,7 +131,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Bump google.golang.org/grpc from 1.51.0 to 1.53.0 in /tests/terraform [(#7879)](https://github.com/k3s-io/k3s/pull/7879)
 * Add retry for clone step [(#7862)](https://github.com/k3s-io/k3s/pull/7862)
 * Generation of certificates and keys for etcd gated if etcd is disabled. [(#6998)](https://github.com/k3s-io/k3s/pull/6998)
-* Don't use zgrep in `check-config` if apparmor porfile is enforced [(#7939)](https://github.com/k3s-io/k3s/pull/7939)
+* Don't use zgrep in `check-config` if apparmor profile is enforced [(#7939)](https://github.com/k3s-io/k3s/pull/7939)
 * Fix image_scan.sh script and download trivy version [(#7950)](https://github.com/k3s-io/k3s/pull/7950)
 * Revert "Warn that v1.28 will deprecate reencrypt/prepare" [(#7977)](https://github.com/k3s-io/k3s/pull/7977)
 * Adjust default kubeconfig file permissions [(#7978)](https://github.com/k3s-io/k3s/pull/7978)


### PR DESCRIPTION
This PR does the following:
* Removes the option `--flannel-backend=wireguard` (deprecated since 1.24 and removed in 1.26)
* Hides the section "Migrating from `wireguard` or `ipsec` to `wireguard-native`" from the side summary
* Updates warning about dualStack node-ip
* Adds known issue when doing dualStack with IPv6 first
* Removes Multicluster CIDR
* Fixed this error thrown by CI:
```
./docs/release-notes/v1.27.X.md:134: porfile ==> profile
Error: Process completed with exit code 6[5](https://github.com/k3s-io/docs/actions/runs/6532077574/job/17734575997?pr=188#step:5:6).
```