### PR TITLE
Embed GH release link in release notes

### DIFF
--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -490,7 +490,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 ### Changes since v1.24.1+k3s1:
 
 * Remove kube-ipvs0 interface when cleaning up [(#5644)](https://github.com/k3s-io/k3s/pull/5644)
-* The `--flannel-wireguard-mode` switch was added to the k3s cli to confgure the wireguard tunnel mode with the wireguard native backend [(#5552)](https://github.com/k3s-io/k3s/pull/5552)
+* The `--flannel-wireguard-mode` switch was added to the k3s cli to configure the wireguard tunnel mode with the wireguard native backend [(#5552)](https://github.com/k3s-io/k3s/pull/5552)
 * Introduce the flannelcniconf flag to set the desired flannel cni configuration [(#5656)](https://github.com/k3s-io/k3s/pull/5656)
 * Integration Test: Startup [(#5630)](https://github.com/k3s-io/k3s/pull/5630)
 * E2E Improvements and groundwork for test-pad tool [(#5593)](https://github.com/k3s-io/k3s/pull/5593)

--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -31,7 +31,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
-## Release v1.24.17+k3s1
+## Release [v1.24.17+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.17+k3s1)
 <!-- v1.24.17+k3s1 -->
 This release updates Kubernetes to v1.24.17, and fixes a number of issues.
 
@@ -68,7 +68,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Add RWMutex to address controller [(#8276)](https://github.com/k3s-io/k3s/pull/8276)
 
 -----
-## Release v1.24.16+k3s1
+## Release [v1.24.16+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.16+k3s1)
 <!-- v1.24.16+k3s1 -->
 
 This release updates Kubernetes to v1.24.16, and fixes a number of issues.
@@ -93,7 +93,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.16 [(#8023)](https://github.com/k3s-io/k3s/pull/8023)
 
 -----
-## Release v1.24.15+k3s1
+## Release [v1.24.15+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.15+k3s1)
 <!-- v1.24.15+k3s1 -->
 This release updates Kubernetes to v1.24.15, and fixes a number of issues.
 
@@ -120,7 +120,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update Kubernetes to v1.24.15 [(#7785)](https://github.com/k3s-io/k3s/pull/7785)
 
 -----
-## Release v1.24.14+k3s1
+## Release [v1.24.14+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.14+k3s1)
 <!-- v1.24.14+k3s1 -->
 This release updates Kubernetes to v1.24.14, and fixes a number of issues.
 
@@ -158,7 +158,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.14-k3s1 [(#7577)](https://github.com/k3s-io/k3s/pull/7577)
 
 -----
-## Release v1.24.13+k3s1
+## Release [v1.24.13+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.13+k3s1)
 <!-- v1.24.13+k3s1 -->
 This release updates Kubernetes to v1.24.13, and fixes a number of issues.
 
@@ -183,7 +183,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.13-k3s1 [(#7284)](https://github.com/k3s-io/k3s/pull/7284)
 
 -----
-## Release v1.24.12+k3s1
+## Release [v1.24.12+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.12+k3s1)
 <!-- v1.24.12+k3s1 -->
 This release updates Kubernetes to v1.24.12, and fixes a number of issues.
 
@@ -202,7 +202,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.12-k3s1 [(#7105)](https://github.com/k3s-io/k3s/pull/7105)
 
 -----
-## Release v1.24.11+k3s1
+## Release [v1.24.11+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.11+k3s1)
 <!-- v1.24.11+k3s1 -->
 This release updates Kubernetes to v1.24.11, and fixes a number of issues.
 
@@ -244,7 +244,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.11-k3s1 [(#7009)](https://github.com/k3s-io/k3s/pull/7009)
 
 -----
-## Release v1.24.10+k3s1
+## Release [v1.24.10+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.10+k3s1)
 <!-- v1.24.10+k3s1 -->
 
 This release updates Kubernetes to v1.24.10+k3s1, and fixes a number of issues.
@@ -260,7 +260,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Bump action/download-artifact to v3 [(#6748)](https://github.com/k3s-io/k3s/pull/6748)
 
 -----
-## Release v1.24.9+k3s2
+## Release [v1.24.9+k3s2](https://github.com/k3s-io/k3s/releases/tag/v1.24.9+k3s2)
 <!-- v1.24.9+k3s2 -->
 
 This release updates containerd to v1.6.14 to resolve an issue where pods would lose their CNI information when containerd was restarted.
@@ -272,7 +272,7 @@ This release updates containerd to v1.6.14 to resolve an issue where pods would 
   * The embedded containerd version has been bumped to v1.6.14-k3s1. This includes a backported fix for [containerd/7843](https://github.com/containerd/containerd/issues/7843) which caused pods to lose their CNI info when containerd was restarted, which in turn caused the kubelet to recreate the pod.
 
 -----
-## Release v1.24.9+k3s1
+## Release [v1.24.9+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.9+k3s1)
 <!-- v1.24.9+k3s1 -->
 
 > ## ⚠️ WARNING
@@ -310,7 +310,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Preload iptable_filter/ip6table_filter [(#6647)](https://github.com/k3s-io/k3s/pull/6647)
 
 -----
-## Release v1.24.8+k3s1
+## Release [v1.24.8+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.8+k3s1)
 <!-- v1.24.8+k3s1 -->
 This release updates Kubernetes to v1.24.8, and fixes a number of issues.
 
@@ -350,7 +350,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Move traefik chart repo again [(#6509)](https://github.com/k3s-io/k3s/pull/6509)
 
 -----
-## Release v1.24.7+k3s1
+## Release [v1.24.7+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.7+k3s1)
 <!-- v1.24.7+k3s1 -->
 This release updates Kubernetes to v1.24.7, and fixes a number of issues.
 
@@ -379,7 +379,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
   * This is meant for use with distributed clusters that are not all on the same local network.
 
 -----
-## Release v1.24.6+k3s1
+## Release [v1.24.6+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.6+k3s1)
 <!-- v1.24.6+k3s1 -->
 This release updates Kubernetes to v1.24.6, and fixes a number of issues.
 
@@ -403,7 +403,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.6-k3s1 [(#6164)](https://github.com/k3s-io/k3s/pull/6164)
 
 -----
-## Release v1.24.4+k3s1
+## Release [v1.24.4+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.4+k3s1)
 <!-- v1.24.4+k3s1 -->
 This release updates Kubernetes to v1.24.4, and fixes a number of issues.
 
@@ -444,7 +444,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.4 [(#6014)](https://github.com/k3s-io/k3s/pull/6014)
 
 -----
-## Release v1.24.3+k3s1
+## Release [v1.24.3+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.3+k3s1)
 <!-- v1.24.3+k3s1 -->
 This release updates Kubernetes to v1.24.3, and fixes a number of issues.
 
@@ -468,7 +468,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.3 [(#5870)](https://github.com/k3s-io/k3s/pull/5870)
 
 -----
-## Release v1.24.2+k3s2
+## Release [v1.24.2+k3s2](https://github.com/k3s-io/k3s/releases/tag/v1.24.2+k3s2)
 <!-- v1.24.2+k3s2 -->
 This fixes several issues in the v1.24.2+k3s1 and prior releases.
 
@@ -481,7 +481,7 @@ This fixes several issues in the v1.24.2+k3s1 and prior releases.
 * Remove go-powershell dead dependency ([#5777](https://github.com/k3s-io/k3s/pull/5777))
 
 -----
-## Release v1.24.2+k3s1
+## Release [v1.24.2+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.2+k3s1)
 <!-- v1.24.2+k3s1 -->
 This release updates Kubernetes to v1.24.2, and fixes a number of issues.
 
@@ -490,7 +490,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 ### Changes since v1.24.1+k3s1:
 
 * Remove kube-ipvs0 interface when cleaning up [(#5644)](https://github.com/k3s-io/k3s/pull/5644)
-* The `--flannel-wireguard-mode` switch was added to the k3s cli to configure the wireguard tunnel mode with the wireguard native backend [(#5552)](https://github.com/k3s-io/k3s/pull/5552)
+* The `--flannel-wireguard-mode` switch was added to the k3s cli to confgure the wireguard tunnel mode with the wireguard native backend [(#5552)](https://github.com/k3s-io/k3s/pull/5552)
 * Introduce the flannelcniconf flag to set the desired flannel cni configuration [(#5656)](https://github.com/k3s-io/k3s/pull/5656)
 * Integration Test: Startup [(#5630)](https://github.com/k3s-io/k3s/pull/5630)
 * E2E Improvements and groundwork for test-pad tool [(#5593)](https://github.com/k3s-io/k3s/pull/5593)
@@ -511,7 +511,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Update to v1.24.2 [(#5749)](https://github.com/k3s-io/k3s/pull/5749)
 
 -----
-## Release v1.24.1+k3s1
+## Release [v1.24.1+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.24.1+k3s1)
 <!-- v1.24.1+k3s1 -->
 This release updates Kubernetes to v1.24.1, and fixes a number of issues.
 

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -38,8 +38,8 @@ for minor in $MINORS; do
         previous=$patch
         # Remove the component table from each individual release notes
         perl -i -p0e 's/^## Embedded Component Versions.*?^-----/-----/gms' "${file}"
-        # Add extra levels for Docusaurus Sidebar
-        sed -i 's/^# Release/## Release/' "${file}"
+        # Add extra levels for Docusaurus Sidebar and link to GH release page
+        sed -i 's/^# Release \(.*\)/## Release [\1](https:\/\/github.com\/k3s-io\/k3s\/releases\/tag\/\1)/' "${file}"
         sed -i 's/^## Changes since/### Changes since/' "${file}"
     done
     echo -e "\n<br />\n" >> $k3s_table


### PR DESCRIPTION
## Changes
- Modify the release notes script to include a external link to the GH release page of each  patch release
- Update v1.24.X.md with new links above (all other release notes will be updated using the workflow bot)

Signed-off-by: Derek Nola <derek.nola@suse.com>