### PR TITLE
Fix outdated/wrong HelmChartConfig example (regarding Traefik forwardedHeaders)

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -134,10 +134,11 @@ spec:
     image:
       name: traefik
       tag: 2.9.10
-    web:
-      forwardedHeaders:
-        trustedIPs:
-          - 10.0.0.0/8
+    ports:
+      web:
+        forwardedHeaders:
+          trustedIPs:
+            - 10.0.0.0/8
 ```
 
 ### Migrating from Helm v2


### PR DESCRIPTION
The example for configuring the Traefik helm chart given here does not work, because the structure does not line up with the values file (the top-level `ports` node is missing). See here: https://github.com/traefik/traefik-helm-chart/blob/d9f4731fce7c8fdb134f417d977537e2ecad1a6e/traefik/values.yaml#L609

I am running `k3s version v1.28.5+k3s1 (5b2d1271)` which contains traefik-helm-chart `traefik-25.0.2+up25.0.0`.

For context:
The documentation here contains an example on how to configure the Helm charts that are shipped with K3s, that is through the `HelmChartConfig` CRD.
More specifically, it is an example that shows how to configure Traefik to trust, i.e. forward the `X-forwarded-*` headers if running behind another reverse proxy. It is exactly the use case I faced so I used it. My changes were not picked up, so I started investigating.

Now I'm seeing that this particular section has been introduced only a few weeks ago (https://github.com/k3s-io/docs/pull/220), which makes me a little uneasy. 