### PR TITLE
Reverse order release notes in sidebar

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch
 
 env:
-  MINORS: "v1.25 v1.26 v1.27 v1.28"
+  MINORS: "v1.26 v1.27 v1.28 v1.29"
 permissions:
   contents: write
   pull-requests: write

--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 6
 ---
 
 # v1.24.X

--- a/docs/release-notes/v1.25.X.md
+++ b/docs/release-notes/v1.25.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 5
 ---
 
 # v1.25.X

--- a/docs/release-notes/v1.26.X.md
+++ b/docs/release-notes/v1.26.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 4
 ---
 
 # v1.26.X

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 3
 ---
 
 # v1.27.X

--- a/docs/release-notes/v1.28.X.md
+++ b/docs/release-notes/v1.28.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 2
 ---
 
 # v1.28.X

--- a/docs/release-notes/v1.29.X.md
+++ b/docs/release-notes/v1.29.X.md
@@ -1,5 +1,6 @@
 ---
 hide_table_of_contents: true
+sidebar_position: 1
 ---
 
 # v1.29.X

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -20,7 +20,7 @@ for minor in $MINORS; do
         body=$(gh release view "${patch}" -R "k3s-io/${product}" --json body -q '.body')
         # Extract from each release notes the component table, building a single table with all the components
         if [ -z "${previous}" ]; then
-            title="---\nhide_table_of_contents: true\n---\n\n# ${minor}.X\n"
+            title="---\nhide_table_of_contents: true\nsidebar_position: 0\n---\n\n# ${minor}.X\n"
             echo -e "${title}" >> $k3s_table
             upgrade_link="[Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-${minor:1}.md#urgent-upgrade-notes)"
             upgrade_warning=":::warning Upgrade Notice\nBefore upgrading from earlier releases, be sure to read the Kubernetes ${upgrade_link}.\n:::\n"
@@ -51,4 +51,13 @@ for minor in $MINORS; do
     k3stmp=$(mktemp)
     cat $k3s_table "${file}" > $k3stmp && mv $k3stmp "${file}"
     echo "Collected release notes for ${product} ${minor}"
+done
+
+# For all the releases, order the release notes in reverse numerical order
+ITER=1
+echo "Reordering release notes in sidebar"
+for file in $(ls -r docs/release-notes/v1.*.X.md); do
+   # Add sidebar_position: $ITER to each release notes
+    sed -i "s/^sidebar_position:.*/sidebar_position: $ITER/" "${file}"
+    ITER=$((ITER+1))
 done


### PR DESCRIPTION
- Adds sidebar ordering to release notes script. Release are ordered in reverse numerical order, with the most recent Minor being at placed at the top.
- Update release notes automation with v1.26-v1.29
Signed-off-by: Derek Nola <derek.nola@suse.com>