### PR TITLE
Fix the `curl` command for preparing k3s images for Airgap

### DIFF
--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -37,7 +37,7 @@ This method requires you to manually deploy the necessary images to each node, a
 2. Download the imagess archive to the agent's images directory, for example:
   ```bash
   sudo mkdir -p /var/lib/rancher/k3s/agent/images/
-  sudo curl -L -O /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.zst https://github.com/k3s-io/k3s/releases/download/v1.29.1-rc2%2Bk3s1/k3s-airgap-images-amd64.tar.zst
+  sudo curl -L -o /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.zst "https://github.com/k3s-io/k3s/releases/download/v1.29.1-rc2%2Bk3s1/k3s-airgap-images-amd64.tar.zst"
   ```
 3. Proceed to the [Install K3s](#install-k3s) section below.
 


### PR DESCRIPTION
Fixes https://github.com/k3s-io/docs/issues/244

This fixes an invalid URL issue that `curl` throws. 
```console
$ sudo curl -L -O /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.zst https://github.com/k3s-io/k3s/releases/download/v1.29.1-rc2%2Bk3s1/k3s-airgap-images-amd64.tar.zst
curl: (3) URL using bad/illegal format or missing URL
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

Since we are already passing the full path to the images.tar.zst, we can use `-o` instead of `-O`
