### PR TITLE
Update manual upgrade page with better order of operations

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = .git,./src,./node_modules,*.js,*.json,./build,./.github,yarn.lock
 check-filenames = true
-ignore-words-list = aks,ec2,eks,gce,gcp,ro,shouldnot,pullrequest
+ignore-words-list = aks,ec2,eks,gce,gcp,ro,shouldnot,pullrequest,readd

--- a/docs/release-notes/v1.26.X.md
+++ b/docs/release-notes/v1.26.X.md
@@ -42,7 +42,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 
 * Chore: bump Local Path Provisioner version [(#9428)](https://github.com/k3s-io/k3s/pull/9428)
 * Bump cri-dockerd to fix compat with Docker Engine 25 [(#9292)](https://github.com/k3s-io/k3s/pull/9292)
-* Auto Dependancy Bump [(#9421)](https://github.com/k3s-io/k3s/pull/9421)
+* Auto Dependency Bump [(#9421)](https://github.com/k3s-io/k3s/pull/9421)
 * Runtimes refactor using exec.LookPath [(#9429)](https://github.com/k3s-io/k3s/pull/9429)
   * Directories containing runtimes need to be included in the $PATH environment variable for effective runtime detection.
 * Changed how lastHeartBeatTime works in the etcd condition [(#9423)](https://github.com/k3s-io/k3s/pull/9423)

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -37,7 +37,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 
 * Chore: bump Local Path Provisioner version [(#9427)](https://github.com/k3s-io/k3s/pull/9427)
 * Bump cri-dockerd to fix compat with Docker Engine 25 [(#9291)](https://github.com/k3s-io/k3s/pull/9291)
-* Auto Dependancy Bump [(#9420)](https://github.com/k3s-io/k3s/pull/9420)
+* Auto Dependency Bump [(#9420)](https://github.com/k3s-io/k3s/pull/9420)
 * Runtimes refactor using exec.LookPath [(#9430)](https://github.com/k3s-io/k3s/pull/9430)
   * Directories containing runtimes need to be included in the $PATH environment variable for effective runtime detection.
 * Changed how lastHeartBeatTime works in the etcd condition [(#9425)](https://github.com/k3s-io/k3s/pull/9425)

--- a/docs/release-notes/v1.28.X.md
+++ b/docs/release-notes/v1.28.X.md
@@ -33,7 +33,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 
 * Chore: bump Local Path Provisioner version [(#9426)](https://github.com/k3s-io/k3s/pull/9426)
 * Bump cri-dockerd to fix compat with Docker Engine 25 [(#9293)](https://github.com/k3s-io/k3s/pull/9293)
-* Auto Dependancy Bump [(#9419)](https://github.com/k3s-io/k3s/pull/9419)
+* Auto Dependency Bump [(#9419)](https://github.com/k3s-io/k3s/pull/9419)
 * Runtimes refactor using exec.LookPath [(#9431)](https://github.com/k3s-io/k3s/pull/9431)
   * Directories containing runtimes need to be included in the $PATH environment variable for effective runtime detection.
 * Changed how lastHeartBeatTime works in the etcd condition [(#9424)](https://github.com/k3s-io/k3s/pull/9424)

--- a/docs/upgrades/killall.md
+++ b/docs/upgrades/killall.md
@@ -6,6 +6,63 @@ weight: 4
 
 To allow high availability during upgrades, the K3s containers continue running when the K3s service is stopped.
 
+
+## K3s Service
+
+Stopping and restarting K3s is supported by the installation script for systemd and OpenRC.
+
+<Tabs>
+<TabItem value="systemd">
+
+To stop servers:
+```sh
+sudo systemctl stop k3s
+```
+
+To restart servers:
+```sh
+sudo systemctl start k3s
+```
+
+To stop agents:
+```sh
+sudo systemctl stop k3s-agent
+```
+
+To restart agents:
+```sh
+sudo systemctl start k3s-agent
+```
+
+</TabItem>
+<TabItem value="OpenRC">
+
+To stop servers:
+```sh
+sudo rc-service k3s stop
+```
+
+To restart servers:
+```sh
+sudo rc-service k3s restart
+```
+
+To stop agents:
+```sh
+sudo rc-service k3s-agent stop
+```
+
+To restart agents:
+```sh
+sudo rc-service k3s-agent restart
+```
+
+</TabItem>
+</Tabs>
+
+
+## Killall Script
+
 To stop all of the K3s containers and reset the containerd state, the `k3s-killall.sh` script can be used.
 
 The killall script cleans up containers, K3s directories, and networking components while also removing the iptables chain with all the associated rules. The cluster data will not be deleted.

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -37,56 +37,61 @@ The contents of the [configuration file](../installation/configuration.md#config
 If you want your configuration to be independent from the install script, you should use a configuration file instead of passing environment variables or arguments to the install script.
 :::
 
-For example, to upgrade to the current stable release:
+1. Stop the old k3s service
+    <Tabs>
+    <TabItem value="systemd">
 
-```sh
-curl -sfL https://get.k3s.io | <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-```
+    To stop servers:
+    ```sh
+    sudo systemctl stop k3s
+    ```
 
-If you want to upgrade to a newer version in a specific channel (such as latest) you can specify the channel:
-```sh
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-```
+    To stop agents:
+    ```sh
+    sudo systemctl stop k3s-agent
+    ```
+    </TabItem>
+    <TabItem value="OpenRC">
 
-If you want to upgrade to a specific version you can run the following command:
+    To stop servers:
+    ```sh
+    sudo rc-service k3s stop
+    ```
 
-```sh
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z-rc1 <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-```
+    To stop agents:
+    ```sh
+    sudo rc-service k3s-agent stop
+    ```
+    </TabItem>
+    </Tabs>
+2. Run the install script to download and start the new k3s service
 
-### Manually Upgrade K3s Using the Binary
+    For example, to upgrade to the current stable release:
 
-Or to manually upgrade K3s:
+    ```sh
+    curl -sfL https://get.k3s.io | <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+    ```
+
+    If you want to upgrade to a newer version in a specific channel (such as latest) you can specify the channel:
+    ```sh
+    curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+    ```
+
+    If you want to upgrade to a specific version you can run the following command:
+
+    ```sh
+    curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z+k3s1 <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+    ```
+
+    :::tip 
+    If you want to download the new verision of k3s, but not start it, you can use the `INSTALL_K3S_SKIP_START=true` environment variable.
+    :::
+
+### Upgrade K3s Using the Binary
+
+To upgrade K3s manually, you can download the desired version of the K3s binary and replace the existing binary with the new one.
 
 1. Download the desired version of the K3s binary from [releases](https://github.com/k3s-io/k3s/releases)
 2. Copy the downloaded binary to `/usr/local/bin/k3s` (or your desired location)
 3. Stop the old k3s binary
 4. Launch the new k3s binary
-
-### Restarting K3s
-
-Restarting K3s is supported by the installation script for systemd and OpenRC.
-
-**systemd**
-
-To restart servers manually:
-```sh
-sudo systemctl restart k3s
-```
-
-To restart agents manually:
-```sh
-sudo systemctl restart k3s-agent
-```
-
-**OpenRC**
-
-To restart servers manually:
-```sh
-sudo service k3s restart
-```
-
-To restart agents manually:
-```sh
-sudo service k3s-agent restart
-```

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -40,8 +40,8 @@ If you want your configuration to be independent from the install script, you sh
 Running the install script will:
 
 1. Download the new k3s binary
-2. Stop the existing k3s service
-3. Start the new k3s service
+2. Update the systemd unit or openrc init script to reflect the args passed to the install script
+3. Restart the k3s service
 
 For example, to upgrade to the current stable release:
 

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -37,55 +37,32 @@ The contents of the [configuration file](../installation/configuration.md#config
 If you want your configuration to be independent from the install script, you should use a configuration file instead of passing environment variables or arguments to the install script.
 :::
 
-1. Stop the old k3s service
-    <Tabs>
-    <TabItem value="systemd">
+Running the install script will:
 
-    To stop servers:
-    ```sh
-    sudo systemctl stop k3s
-    ```
+1. Download the new k3s binary
+2. Stop the existing k3s service
+3. Start the new k3s service
 
-    To stop agents:
-    ```sh
-    sudo systemctl stop k3s-agent
-    ```
-    </TabItem>
-    <TabItem value="OpenRC">
+For example, to upgrade to the current stable release:
 
-    To stop servers:
-    ```sh
-    sudo rc-service k3s stop
-    ```
+```sh
+curl -sfL https://get.k3s.io | <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+```
 
-    To stop agents:
-    ```sh
-    sudo rc-service k3s-agent stop
-    ```
-    </TabItem>
-    </Tabs>
-2. Run the install script to download and start the new k3s service
+If you want to upgrade to a newer version in a specific channel (such as latest) you can specify the channel:
+```sh
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+```
 
-    For example, to upgrade to the current stable release:
+If you want to upgrade to a specific version you can run the following command:
 
-    ```sh
-    curl -sfL https://get.k3s.io | <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-    ```
+```sh
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z+k3s1 <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
+```
 
-    If you want to upgrade to a newer version in a specific channel (such as latest) you can specify the channel:
-    ```sh
-    curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-    ```
-
-    If you want to upgrade to a specific version you can run the following command:
-
-    ```sh
-    curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z+k3s1 <EXISTING_K3S_ENV> sh -s - <EXISTING_K3S_ARGS>
-    ```
-
-    :::tip 
-    If you want to download the new verision of k3s, but not start it, you can use the `INSTALL_K3S_SKIP_START=true` environment variable.
-    :::
+:::tip 
+If you want to download the new verision of k3s, but not start it, you can use the `INSTALL_K3S_SKIP_START=true` environment variable.
+:::
 
 ### Upgrade K3s Using the Binary
 


### PR DESCRIPTION
Addresses: https://github.com/k3s-io/docs/issues/178

~~Mentions that you have to stop the existing K3s service before running the installation script with a new version.~~