### PR TITLE
Remove unnecessary 'request-timeout=300s' parameter from CIS hardening guide

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -45,7 +45,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -573,7 +573,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -596,7 +595,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
@@ -34,7 +34,6 @@ kube-apiserver-arg:
   - "audit-log-maxage=30"
   - "audit-log-maxbackup=10"
   - "audit-log-maxsize=100"
-  - "request-timeout=300s"
 kube-controller-manager-arg:
   - "terminated-pod-gc-threshold=10"
   - "use-service-account-credentials=true"

--- a/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -575,7 +575,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -598,7 +597,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/kr/docusaurus-plugin-content-docs/current/security/self-assessment-1.23.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/security/self-assessment-1.23.md
@@ -1004,10 +1004,14 @@ Sep 13 13:26:40 k3s-123-cis-pool3-b403f678-bzdg5 k3s[1600]: time="2022-09-13T13:
 **Result:** Not Applicable
 
 **Remediation:**
-Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
-on the control plane node and set the --service-account-key-file parameter
-to the public key file for service accounts. For example,
-`--service-account-key-file=<filename>`.
+The request timeout limits the duration of API requests. The default value of 60 seconds is 
+sufficiently low already. Only change the default value if necessary. When extending this 
+limit, make sure to keep it low enough. A large value can exhaust API server resources and 
+make it prone for Denial-of-Service attacks.
+
+Edit the config file /etc/rancher/k3s/config.yaml on the control plane node and remove the 
+--request-timeout parameter or set it to an appropriate value if needed. For example,
+`--request-timeout=300s`.
 
 ### 1.2.26 Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
@@ -32,7 +32,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -578,7 +578,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -601,7 +600,6 @@ kube-apiserver-arg:
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
-  - 'request-timeout=300s'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'


### PR DESCRIPTION
CIS [recommends](https://github.com/k3s-io/docs/blob/main/docs/security/hardening-guide.md#control-1226) to set the `--request-timeout` parameter *only when necessary*. The default already limits requests to 60 seconds and increasing this would not improve the security. Hence, the suggestion to increase this parameter to 300 seconds should be removed from the hardening guide.

