### PR TITLE
Remove unnecessary 'service-account-lookup=true' from hardening guide

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -47,7 +47,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -575,7 +575,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -599,7 +598,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
@@ -36,7 +36,6 @@ kube-apiserver-arg:
   - "audit-log-maxbackup=10"
   - "audit-log-maxsize=100"
   - "request-timeout=300s"
-  - "service-account-lookup=true"
 kube-controller-manager-arg:
   - "terminated-pod-gc-threshold=10"
   - "use-service-account-credentials=true"

--- a/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -577,7 +577,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -601,7 +600,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
@@ -34,7 +34,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -580,7 +580,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'
@@ -604,7 +603,6 @@ kube-apiserver-arg:
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'
   - 'request-timeout=300s'
-  - 'service-account-lookup=true'
 kube-controller-manager-arg:
   - 'terminated-pod-gc-threshold=10'
   - 'use-service-account-credentials=true'


### PR DESCRIPTION
CIS [recommends](https://github.com/k3s-io/docs/blob/main/docs/security/self-assessment.md#1224-ensure-that-the---service-account-lookup-argument-is-set-to-true-automated) to set the --service-account-lookup parameter to true or *remove it from the config file so that the default applies*. 

This parameter is enabled by default already since [kubernetes #44071](https://github.com/kubernetes/kubernetes/pull/44071). Therefore I propose to remove this parameter from the example configuration in the hardening guide.