### PR TITLE
Remove unnecessary 'make-iptables-util-chains=true' from hardening guide

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -53,7 +53,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 2. Create the `/var/lib/rancher/k3s/server/psa.yaml` file with the following contents. You may want to exempt more namespaces as well. The below example exempts `kube-system` (required), `cis-operator-system` (optional, but useful for when running security scans through Rancher), and `system-upgrade` (required if doing [Automated Upgrades](./upgrades/automated.md)).
 ```yaml

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -581,7 +581,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>
@@ -605,7 +604,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>

--- a/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
@@ -42,7 +42,6 @@ kube-controller-manager-arg:
   - "use-service-account-credentials=true"
 kubelet-arg:
   - "streaming-connection-idle-timeout=5m"
-  - "make-iptables-util-chains=true"
 ```
 
 2. `/var/lib/rancher/k3s/server/psa.yaml` 파일을 다음 내용으로 작성합니다. 더 많은 네임스페이스를 제외할 수도 있습니다. 아래 예시는 `kube-system`(필수), `cis-operator-system`(선택적이지만 Rancher를 통해 보안 스캔을 실행할 때 유용), `system-upgrade`(자동 업그레이드를 수행하는 경우 필수)을 제외합니다.

--- a/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -583,7 +583,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>
@@ -607,7 +606,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
@@ -40,7 +40,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 2. 使用以下内容创建 `/var/lib/rancher/k3s/server/psa.yaml` 文件。你可能还想豁免更多命名空间。下面的示例豁免了 `kube-system`（必需）、`cis-operator-system`（可选，但在通过 Rancher 运行安全扫描时很有用）和 `system- upgrade`（如果执行[自动升级](./upgrades/automated.md)则需要）。
 ```yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening-guide.md
@@ -586,7 +586,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>
@@ -610,7 +609,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 
 </TabItem>


### PR DESCRIPTION
CIS [recommends](https://github.com/k3s-io/docs/blob/main/docs/security/self-assessment.md#427-ensure-that-the---make-iptables-util-chains-argument-is-set-to-true-automated) to *remove* the `--make-iptables-util-chains` argument from the `KUBELET_SYSTEM_PODS_ARGS` variable or set it as true. This parameter is already [true by default](https://github.com/kubernetes/kubernetes/blob/69b648a1d7074cbe004bf7adb3cdb17f01a4e9d8/pkg/kubelet/apis/config/v1beta1/defaults.go#L225). Therefore I suggest to remove this from the hardening guide.