### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -74,7 +74,7 @@ plugins:
 </TabItem>
 <TabItem value="v1.24 and Older" default>
 
-K3s v1.24 and older support [Pod Security Policies (PSPs)](https://v1-24.docs.kubernetes.io/docs/concepts/security/pod-security-policy/) for controlling pod security. PSPs are enabled by passing the following flag to the K3s server:
+K3s v1.24 and older support [Pod Security Policies (PSPs)](https://kubernetes.io/docs/concepts/security/pod-security-policy/) for controlling pod security. PSPs are enabled by passing the following flag to the K3s server:
 
 ```
 --kube-apiserver-arg="enable-admission-plugins=NodeRestriction,PodSecurityPolicy"

--- a/docs/upgrades/manual.md
+++ b/docs/upgrades/manual.md
@@ -60,7 +60,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z+k3s1 <EXISTING_K3S_ENV
 ```
 
 :::tip 
-If you want to download the new verision of k3s, but not start it, you can use the `INSTALL_K3S_SKIP_START=true` environment variable.
+If you want to download the new version of k3s, but not start it, you can use the `INSTALL_K3S_SKIP_START=true` environment variable.
 :::
 
 ### Upgrade K3s Using the Binary

--- a/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/known-issues.md
@@ -19,7 +19,7 @@ title: 已知问题
 
 ### 将强化集群从 v1.24.x 升级到 v1.25.x {#hardened-125}
 
-Kubernetes v1.25 删除了 PodSecurityPolicy，支持 Pod Security Standard（PSS）。你可以在[上游文档](https://kubernetes.io/docs/concepts/security/pod-security-standards/)中阅读有关 PSS 的更多信息。对于 K3s，如果在节点上配置了任何 `PodSecurityPoliciy`，则必须执行一些手动步骤。
+Kubernetes v1.25 删除了 PodSecurityPolicy，支持 Pod Security Standard（PSS）。你可以在[上游文档](https://kubernetes.io/docs/concepts/security/pod-security-standards/)中阅读有关 PSS 的更多信息。对于 K3s，如果在节点上配置了任何 `PodSecurityPolicy`，则必须执行一些手动步骤。
 
 1. 在所有节点上，更新 `kube-apiserver-arg` 值以删除 `PodSecurityPolicy` admission-plugin。添加以下参数值：`'admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml'`，但不要重启或升级 K3s。以下是节点加固更新后配置文件的示例：
 ```yaml


### PR DESCRIPTION
## Description
Correct the typos in the documentation: change `verision` to `version` and `PodSecurityPoliciy` to `PodSecurityPolicy`.