### PR TITLE
Run spellcheck before attempting to open a PR on release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
       - name: Remove old release notes
         run: |
           for minor in $MINORS; do
@@ -22,6 +24,11 @@ jobs:
         run: scripts/collect-all-release-notes.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install codespell and run spell check
+        run: |
+          python -m pip install --upgrade pip
+          pip install codespell
+          codespell
       - name: Get current month and year
         id: date
         run: echo "::set-output name=month_year::$(date +'%B %Y')"

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -62,7 +62,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
   * Fix issue with k3s-etcd informers not starting
   * `--Enable-pprof` can now be set on agents to enable the debug/pprof endpoints. When set, agents will listen on the supervisor port.
   * `--Supervisor-metrics` can now be set on servers to enable serving internal metrics on the supervisor endpoint; when set agents will listen on the supervisor port.
-  * Fix netpol crash when node remains tained unintialized
+  * Fix netpol crash when node remains tainted uninitialized
   * The embedded load-balancer will now fall back to trying all servers with health-checks ignored, if all servers have been marked unavailable due to failed health checks.
 * More backports for 2024-06 release cycle [(#10290)](https://github.com/k3s-io/k3s/pull/10290)
 * Add snapshot retention etcd-s3-folder fix [(#10314)](https://github.com/k3s-io/k3s/pull/10314)

--- a/docs/release-notes/v1.28.X.md
+++ b/docs/release-notes/v1.28.X.md
@@ -58,7 +58,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
   * Fix issue with k3s-etcd informers not starting
   * `--Enable-pprof` can now be set on agents to enable the debug/pprof endpoints. When set, agents will listen on the supervisor port.
   * `--Supervisor-metrics` can now be set on servers to enable serving internal metrics on the supervisor endpoint; when set agents will listen on the supervisor port.
-  * Fix netpol crash when node remains tained unintialized
+  * Fix netpol crash when node remains tainted uninitialized
   * The embedded load-balancer will now fall back to trying all servers with health-checks ignored, if all servers have been marked unavailable due to failed health checks.
 * More backports for 2024-06 release cycle [(#10289)](https://github.com/k3s-io/k3s/pull/10289)
 * Add snapshot retention etcd-s3-folder fix [(#10315)](https://github.com/k3s-io/k3s/pull/10315)

--- a/docs/release-notes/v1.29.X.md
+++ b/docs/release-notes/v1.29.X.md
@@ -52,14 +52,14 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
   * Fix issue with k3s-etcd informers not starting
   * `--Enable-pprof` can now be set on agents to enable the debug/pprof endpoints. When set, agents will listen on the supervisor port.
   * `--Supervisor-metrics` can now be set on servers to enable serving internal metrics on the supervisor endpoint; when set agents will listen on the supervisor port.
-  * Fix netpol crash when node remains tained unintialized
+  * Fix netpol crash when node remains tainted uninitialized
   * The embedded load-balancer will now fall back to trying all servers with health-checks ignored, if all servers have been marked unavailable due to failed health checks.
 * More backports for 2024-06 release cycle [(#10288)](https://github.com/k3s-io/k3s/pull/10288)
 * Add snapshot retention etcd-s3-folder fix [(#10316)](https://github.com/k3s-io/k3s/pull/10316)
 * Add test for `isValidResolvConf` (#10302) [(#10329)](https://github.com/k3s-io/k3s/pull/10329)
 * Fix race condition panic in loadbalancer.nextServer [(#10322)](https://github.com/k3s-io/k3s/pull/10322)
 * Fix typo, use `rancher/permissions` [(#10298)](https://github.com/k3s-io/k3s/pull/10298)
-* Expand GHA go caching to includ newest release branch [(#10334)](https://github.com/k3s-io/k3s/pull/10334)
+* Expand GHA go caching to include newest release branch [(#10334)](https://github.com/k3s-io/k3s/pull/10334)
 * Update Kubernetes to v1.29.6 [(#10348)](https://github.com/k3s-io/k3s/pull/10348)
 * Fix agent supervisor port using apiserver port instead [(#10354)](https://github.com/k3s-io/k3s/pull/10354)
 * Fix issue that allowed multiple simultaneous snapshots to be allowed [(#10376)](https://github.com/k3s-io/k3s/pull/10376)

--- a/docs/release-notes/v1.30.X.md
+++ b/docs/release-notes/v1.30.X.md
@@ -67,7 +67,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Bump alpine from 3.18 to 3.20 in /package [(#10211)](https://github.com/k3s-io/k3s/pull/10211)
 * Bump ubuntu from 22.04 to 24.04 in /tests/e2e/scripts [(#10040)](https://github.com/k3s-io/k3s/pull/10040)
 * Bump Trivy version [(#10039)](https://github.com/k3s-io/k3s/pull/10039)
-* Fix netpol crash when node remains tained unintialized [(#10073)](https://github.com/k3s-io/k3s/pull/10073)
+* Fix netpol crash when node remains tainted uninitialized [(#10073)](https://github.com/k3s-io/k3s/pull/10073)
 * Fix issue caused by sole server marked as failed under load [(#10241)](https://github.com/k3s-io/k3s/pull/10241)
   * The embedded load-balancer will now fall back to trying all servers with health-checks ignored, if all servers have been marked unavailable due to failed health checks.
 * Add write-kubeconfig-group flag to server [(#9233)](https://github.com/k3s-io/k3s/pull/9233)
@@ -79,7 +79,7 @@ For more details on what's new, see the [Kubernetes release notes](https://githu
 * Add ADR for support for etcd s3 config secret [(#9364)](https://github.com/k3s-io/k3s/pull/9364)
 * Add test for `isValidResolvConf` [(#10302)](https://github.com/k3s-io/k3s/pull/10302)
 * Add snapshot retention etcd-s3-folder fix [(#10293)](https://github.com/k3s-io/k3s/pull/10293)
-* Expand GHA golang caching to includ newest release branch [(#10307)](https://github.com/k3s-io/k3s/pull/10307)
+* Expand GHA golang caching to include newest release branch [(#10307)](https://github.com/k3s-io/k3s/pull/10307)
 * Fix race condition panic in loadbalancer.nextServer [(#10318)](https://github.com/k3s-io/k3s/pull/10318)
 * Fix typo, use `rancher/permissions` [(#10296)](https://github.com/k3s-io/k3s/pull/10296)
 * Update Kubernetes to v1.30.2 [(#10349)](https://github.com/k3s-io/k3s/pull/10349)


### PR DESCRIPTION
- Since we can't trigger CI when we automatically open a PR for release-notes (recursion prevention), we need to check spellcheck first before allowing the PR to be opened. 
- Spelling fixes in Releases