### PR TITLE
Replace `etcd-snapshot` with `etcd-snapshot save`

### DIFF
--- a/docs/cli/etcd-snapshot.md
+++ b/docs/cli/etcd-snapshot.md
@@ -109,7 +109,7 @@ The arguments below have been added to the `server` subcommand. These flags exis
 To perform an on-demand etcd snapshot and save it to S3:
 
 ```bash
-k3s etcd-snapshot \
+k3s etcd-snapshot save \
   --s3 \
   --s3-bucket=<S3-BUCKET-NAME> \
   --s3-access-key=<S3-ACCESS-KEY> \


### PR DESCRIPTION
This change replaces the `etcd-snapshot` subcommand with `etcd-snapshot save` in the example, to conform with what the note indicates:

https://github.com/k3s-io/docs/blob/492ecff6ee19f00a84c7e306d5c0c71cd8edaab4/docs/cli/etcd-snapshot.md?plain=1#L144