### PR TITLE
Add notice for Ubuntu 24.04 on Raspberry Pi

### DIFF
--- a/docs/cli/etcd-snapshot.md
+++ b/docs/cli/etcd-snapshot.md
@@ -24,7 +24,7 @@ When K3s is restored from backup, the old data directory will be moved to `${dat
 
 To restore the cluster from backup:
 
-<Tabs>
+<Tabs queryString="etcdsnap">
 <TabItem value="Single Server">
 
 Run K3s with the `--cluster-reset` option, with the `--cluster-reset-restore-path` also given:

--- a/docs/cli/secrets-encrypt.md
+++ b/docs/cli/secrets-encrypt.md
@@ -31,7 +31,7 @@ Available as of [v1.28.1+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.28.
 For older releases, see [Encryption Key Rotation Classic](#encryption-key-rotation-classic)
 :::
 
-<Tabs groupId="se">
+<Tabs groupId="se" queryString>
 <TabItem value="Single-Server" default>
 To rotate secrets encryption keys on a single-server cluster:
 
@@ -97,7 +97,7 @@ To rotate secrets encryption keys on HA setups:
 
 ### Encryption Key Rotation Classic
 
-<Tabs groupId="se">
+<Tabs groupId="se" queryString>
 <TabItem value="Single-Server" default>
 
 To rotate secrets encryption keys on a single-server cluster:
@@ -195,7 +195,7 @@ To rotate secrets encryption keys on HA setups:
 </Tabs>
 
 ### Secrets Encryption Disable/Re-enable
-<Tabs groupId="se">
+<Tabs groupId="se" queryString>
 <TabItem value="Single-Server" default>
 
 After launching a server with `--secrets-encryption` flag, secrets encryption can be disabled.

--- a/docs/datastore/cluster-loadbalancer.md
+++ b/docs/datastore/cluster-loadbalancer.md
@@ -40,7 +40,7 @@ Three additional nodes exist with hostnames and IPs of:
 * agent-3: `10.10.10.103`
 
 ## Setup Load Balancer
-<Tabs>
+<Tabs queryString="ext-load-balancer">
 <TabItem value="HAProxy" default>
 
 [HAProxy](http://www.haproxy.org/) is an open source option that provides a TCP load balancer. It also supports HA for the load balancer itself, ensuring redundancy at all levels. See [HAProxy Documentation](http://docs.haproxy.org/2.8/intro.html) for more info.

--- a/docs/datastore/datastore.md
+++ b/docs/datastore/datastore.md
@@ -44,7 +44,7 @@ As a best practice we recommend setting these parameters as environment variable
 ### Datastore Endpoint Format and Functionality
 As mentioned, the format of the value passed to the `datastore-endpoint` parameter is dependent upon the datastore backend. The following details this format and functionality for each supported external datastore.
 
-<Tabs>
+<Tabs queryString="ext-db">
 <TabItem value="PostgreSQL">
 
 

--- a/docs/installation/airgap.md
+++ b/docs/installation/airgap.md
@@ -93,7 +93,7 @@ See the [SELinux](../advanced.md#selinux-support) section for more information.
 
 You can install K3s on one or more servers as described below.
 
-<Tabs>
+<Tabs queryString="airgap-cluster">
 <TabItem value="Single Server Configuration" default>
 
 To install K3s on a single server, simply do the following on the server node:

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -102,7 +102,7 @@ Example cmdline.txt:
 console=serial0,115200 console=tty1 root=PARTUUID=58b06195-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_memory=1 cgroup_enable=memory
 ```
 
-Starting with Ubuntu 21.10, vxlan support on Raspberry Pi has been moved into a separate kernel module. 
+With Ubuntu 21.10 to Ubuntu 23.10, vxlan support on Raspberry Pi was moved into a separate kernel module. This step in not required for Ubuntu 24.04 and later.
 ```bash
 sudo apt install linux-modules-extra-raspi
 ```

--- a/docs/networking/basic-network-options.md
+++ b/docs/networking/basic-network-options.md
@@ -47,7 +47,7 @@ We recommend that users migrate to the new backend as soon as possible. The migr
 
 Start K3s with `--flannel-backend=none` and install your CNI of choice. Most CNI plugins come with their own network policy engine, so it is recommended to set `--disable-network-policy` as well to avoid conflicts. Some important information to take into consideration:
 
-<Tabs>
+<Tabs queryString="cni">
 <TabItem value="Canal" default>
 
 Visit the [Canal Docs](https://docs.tigera.io/calico/latest/getting-started/kubernetes/flannel/install-for-flannel#installing-calico-for-policy-and-flannel-aka-canal-for-networking) website. Follow the steps to install Canal. Modify the Canal YAML so that IP forwarding is allowed in the `container_settings` section, for example:

--- a/i18n/kr/docusaurus-plugin-content-docs/current/advanced.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/advanced.md
@@ -314,7 +314,7 @@ firewall-cmd --permanent --zone=trusted --add-source=10.43.0.0/16 #services
 firewall-cmd --reload
 ```
 
-설정에 따라 추가 포트를 열어야 할 수도 있습니다. 자세한 내용은 [인바운드 규칙](./installation/requirements.md#inbound-rules-for-k3s-server-nodes)을 참조하세요. 파드 또는 서비스에 대한 기본 CIDR을 변경하는 경우, 그에 따라 방화벽 규칙을 업데이트해야 합니다.
+설정에 따라 추가 포트를 열어야 할 수도 있습니다. 자세한 내용은 [인바운드 규칙](./installation/requirements.md#inbound-rules-for-k3s-nodes)을 참조하세요. 파드 또는 서비스에 대한 기본 CIDR을 변경하는 경우, 그에 따라 방화벽 규칙을 업데이트해야 합니다.
 
 활성화된 경우, nm-cloud-setup을 비활성화하고 노드를 재부팅해야 합니다:
 
@@ -339,11 +339,11 @@ ufw allow from 10.42.0.0/16 to any #pods
 ufw allow from 10.43.0.0/16 to any #services
 ```
 
-설정에 따라 추가 포트를 열어야 할 수도 있습니다. 자세한 내용은 [인바운드 규칙](./installation/requirements.md#inbound-rules-for-k3s-server-nodes)을 참조한다. 파드 또는 서비스에 대한 기본 CIDR을 변경하는 경우, 그에 따라 방화벽 규칙을 업데이트해야 합니다.
+설정에 따라 추가 포트를 열어야 할 수도 있습니다. 자세한 내용은 [인바운드 규칙](./installation/requirements.md#inbound-rules-for-k3s-nodes)을 참조한다. 파드 또는 서비스에 대한 기본 CIDR을 변경하는 경우, 그에 따라 방화벽 규칙을 업데이트해야 합니다.
 
 ### Raspberry Pi
 
-라즈베리파이 OS는 데비안 기반이며, 오래된 iptables 버전으로 인해 문제가 발생할 수 있습니다. [해결 방법](#old-iptables-versions)을 참조하세요.
+라즈베리파이 OS는 데비안 기반이며, 오래된 iptables 버전으로 인해 문제가 발생할 수 있습니다. [해결 방법](#이전-iptables-버전)을 참조하세요.
 
 표준 라즈베리파이 OS 설치는 `cgroups`가 활성화된 상태에서 시작되지 않습니다. **K3S**는 systemd 서비스를 시작하기 위해 `cgroups`가 필요합니다. `cgroups`는 `/boot/cmdline.txt`에 `cgroup_memory=1 cgroup_enable=memory`를 추가하여 활성화할 수 있습니다.
 

--- a/i18n/kr/docusaurus-plugin-content-docs/current/architecture.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/architecture.md
@@ -11,7 +11,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 - 서버 노드는 `k3s server` 명령을 실행하는 호스트로 정의되며, 컨트롤 플레인 및 데이터스토어 구성 요소는 K3s에서 관리합니다.
 - 에이전트 노드는 데이터스토어 또는 컨트롤 플레인 구성 요소 없이 `k3s agent` 명령을 실행하는 호스트로 정의됩니다.
-- 서버와 에이전트 모두 kubelet, 컨테이너 런타임 및 CNI를 실행합니다. 에이전트 없는 서버 실행에 대한 자세한 내용은 [고급 옵션](./advanced.md#running-agentless-servers-experimental) 설명서를 참조하세요.
+- 서버와 에이전트 모두 kubelet, 컨테이너 런타임 및 CNI를 실행합니다. 에이전트 없는 서버 실행에 대한 자세한 내용은 [고급 옵션](./advanced.md#에이전트-없는-서버-실행하기실험적) 설명서를 참조하세요.
 
 ![](/img/how-it-works-k3s-revised.svg)
 

--- a/i18n/kr/docusaurus-plugin-content-docs/current/cli/server.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/cli/server.md
@@ -166,7 +166,7 @@ The following options must be set to the same value on all servers in the cluste
 | `--enable-pprof`       | Enable pprof endpoint on supervisor port |
 | `--docker`             | Use cri-dockerd instead of containerd    |
 | `--prefer-bundled-bin` | Prefer bundled userspace binaries over host binaries |
-| `--disable-agent`      | See "[Running Agentless Servers (Experimental)](../advanced.md#running-agentless-servers-experimental)" |
+| `--disable-agent`      | See "[Running Agentless Servers (Experimental)](../advanced.md#에이전트-없는-서버-실행하기실험적)" |
 
 
 ### Deprecated Options

--- a/i18n/kr/docusaurus-plugin-content-docs/current/faq.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/faq.md
@@ -58,7 +58,7 @@ K3s를 배포하는 데 문제가 있는 경우 다음과 같이 하세요:
 
 1. [알려진 문제](./known-issues.md) 페이지를 확인하세요.
 
-2. [추가 OS 준비사항](./advanced.md#additional-os-preparations)을 모두 해결했는지 확인합니다. `k3s check-config`를 실행하고 통과했는지 확인합니다.
+2. [추가 OS 준비사항](./advanced.md#추가-os-준비-사항)을 모두 해결했는지 확인합니다. `k3s check-config`를 실행하고 통과했는지 확인합니다.
 
 3. K3s [이슈](https://github.com/k3s-io/k3s/issues) 및 [토론](https://github.com/k3s-io/k3s/discussions)에서 문제와 일치하는 항목을 검색합니다.
 

--- a/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/known-issues.md
@@ -12,7 +12,7 @@ title: 알려진 이슈
 
 레거시 대신 nftables 모드에서 iptables를 실행하는 경우 문제가 발생할 수 있습니다. 문제를 방지하려면 최신 버전(예: 1.6.1+)의 iptables를 사용하는 것이 좋습니다.
 
-또한 1.8.0-1.8.4 버전에는 K3s가 실패할 수 있는 알려진 문제가 있습니다. 해결 방법은 [추가 OS 준비](./advanced.md#old-iptables-versions)를 참조하세요.
+또한 1.8.0-1.8.4 버전에는 K3s가 실패할 수 있는 알려진 문제가 있습니다. 해결 방법은 [추가 OS 준비](./advanced.md#이전-iptables-버전)를 참조하세요.
 
 ### Rootless Mode
 

--- a/i18n/kr/docusaurus-plugin-content-docs/current/networking/basic-network-options.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/networking/basic-network-options.md
@@ -117,7 +117,7 @@ K3s agents and servers maintain websocket tunnels between nodes that are used to
 This allows agents to operate without exposing the kubelet and container runtime streaming ports to incoming connections, and for the control-plane to connect to cluster services when operating with the agent disabled.
 This functionality is equivalent to the [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) service commonly used on other Kubernetes distributions, and is managed via the apiserver's egress selector configuration.
 
-The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#running-agentless-servers-experimental), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
+The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#에이전트-없는-서버-실행하기실험적), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
 
 The egress selector mode may be configured on servers via the `--egress-selector-mode` flag, and offers four modes:
 * `disabled`: The apiserver does not use agent tunnels to communicate with kubelets or cluster endpoints.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/network-options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/network-options.md
@@ -119,7 +119,7 @@ K3s agents and servers maintain websocket tunnels between nodes that are used to
 This allows agents to operate without exposing the kubelet and container runtime streaming ports to incoming connections, and for the control-plane to connect to cluster services when operating with the agent disabled.
 This functionality is equivalent to the [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) service commonly used on other Kubernetes distributions, and is managed via the apiserver's egress selector configuration.
 
-The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#running-agentless-servers-experimental), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
+The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#运行无-agent-的-server实验性), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
 
 The egress selector mode may be configured on servers via the `--egress-selector-mode` flag, and offers four modes:
 * `disabled`: The apiserver does not use agent tunnels to communicate with kubelets or cluster endpoints.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/networking/basic-network-options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/networking/basic-network-options.md
@@ -117,7 +117,7 @@ K3s agents and servers maintain websocket tunnels between nodes that are used to
 This allows agents to operate without exposing the kubelet and container runtime streaming ports to incoming connections, and for the control-plane to connect to cluster services when operating with the agent disabled.
 This functionality is equivalent to the [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) service commonly used on other Kubernetes distributions, and is managed via the apiserver's egress selector configuration.
 
-The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#running-agentless-servers-experimental), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
+The default mode is `agent`. `pod` or `cluster` modes are recommended when running [agentless servers](../advanced.md#运行无-agent-的-server实验性), in order to provide the apiserver with access to cluster service endpoints in the absence of flannel and kube-proxy.
 
 The egress selector mode may be configured on servers via the `--egress-selector-mode` flag, and offers four modes:
 * `disabled`: The apiserver does not use agent tunnels to communicate with kubelets or cluster endpoints.


### PR DESCRIPTION
- Ubuntu 24.04 no longer requires the extra modules for vxlan on Raspberry Pi
- Added more queryString support to make linking to specific tabs easier