### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,7 @@ title: "Quick-Start Guide"
 
 This guide will help you quickly launch a cluster with default options. The [installation section](./installation/installation.md) covers in greater detail how K3s can be set up.
 
-Make sure your nodes meet the the [requirements](./installation/requirements.md) before proceeding.
+Make sure your nodes meet the [requirements](./installation/requirements.md) before proceeding.
 
 For information on how K3s components work together, refer to the [architecture section.](./architecture.md)
 


### PR DESCRIPTION
It was a doubled "*the*" word.