### PR TITLE
Only run release-notes PR automatically on k3s-io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cname: docs.k3s.io

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
 jobs:
   collect-all:
+    if: github.repository == 'k3s-io/docs'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
- the new cron job was opening PRs on dev forks.