### PR TITLE
update keepalived config example

### DIFF
--- a/docs/datastore/cluster-loadbalancer.md
+++ b/docs/datastore/cluster-loadbalancer.md
@@ -76,6 +76,11 @@ backend k3s-backend
 3) Add the following to `/etc/keepalived/keepalived.conf` on lb-1 and lb-2:
 
 ```
+global_defs {
+  enable_script_security
+  script_user root
+}
+
 vrrp_script chk_haproxy {
     script 'killall -0 haproxy' # faster than pidof
     interval 2


### PR DESCRIPTION
Add script security option for the keepalived (required in current version of the daemon)

When not configured, keepalived emits a security violation error at start:

```
Aug 12 11:24:26 k3s-lb-test-1 Keepalived_vrrp[11314]: WARNING - default user 'keepalived_script' for script execution does not exist - please create.
Aug 12 11:24:26 k3s-lb-test-1 Keepalived_vrrp[11314]: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
Aug 12 11:24:26 k3s-lb-test-1 Keepalived_vrrp[11314]: VRRP_Script(chk_haproxy) succeeded
Aug 12 11:24:26 k3s-lb-test-1 Keepalived_vrrp[11314]: (haproxy-vip) Entering BACKUP STATE
```