### PR TITLE
reorder documentation steps

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -111,12 +111,7 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.0/depl
 
 Longhorn will be installed in the namespace `longhorn-system`.
 
-Apply the yaml to create the PVC and pod:
-
-```bash
-kubectl create -f pvc.yaml
-kubectl create -f pod.yaml
-```
+Create a persistent volume claim and a pod to utilize it:
 
 ### pvc.yaml
 
@@ -156,6 +151,13 @@ spec:
   - name: volv
     persistentVolumeClaim:
       claimName: longhorn-volv-pvc
+```
+
+Apply the yaml to create the PVC and pod:
+
+```bash
+kubectl create -f pvc.yaml
+kubectl create -f pod.yaml
 ```
 
 Confirm the PV and PVC are created:


### PR DESCRIPTION
Relevant docs page: https://docs.k3s.io/storage

if you read the previous section (Local Storage Provider) the order is:
1. create yaml files
2. apply yaml
3. confirm changes

But the longhorn section has the ordering:
1. install Longhorn
2. apply yaml files
3. define yaml files
4. confirm changes

I believe steps 2 and 3 are erroneously in the wrong order.