### PR TITLE
Remove lingering make-iptables-util-chains reference

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -50,7 +50,6 @@ kube-controller-manager-arg:
   - 'use-service-account-credentials=true'
 kubelet-arg:
   - 'streaming-connection-idle-timeout=5m'
-  - 'make-iptables-util-chains=true'
 ```
 2. Create the `/var/lib/rancher/k3s/server/psa.yaml` file with the following contents. You may want to exempt more namespaces as well. The below example exempts `kube-system` (required), `cis-operator-system` (optional, but useful for when running security scans through Rancher), and `system-upgrade` (required if doing [Automated Upgrades](./upgrades/automated.md)).
 ```yaml


### PR DESCRIPTION
With the releases of [security-scan v0.2.17](https://github.com/rancher/security-scan/releases/tag/v0.2.17), the checks no longer look for `make-iptables-util-chains` explicitly (as its nonexistence is also allowed).