### PR TITLE
IPv6 networking: mention --flannel-ipv6-masq in dual stack and single stack ipv6 section

### DIFF
--- a/docs/networking/basic-network-options.md
+++ b/docs/networking/basic-network-options.md
@@ -159,6 +159,8 @@ To enable dual-stack in K3s, you must provide valid dual-stack `cluster-cidr` an
 
 Note that you may configure any valid `cluster-cidr` and `service-cidr` values, but the above masks are recommended. If you change the `cluster-cidr` mask, you should also change the `node-cidr-mask-size-ipv4` and `node-cidr-mask-size-ipv6` values to match the planned pods per node and total node count. The largest supported `service-cidr` mask is /12 for IPv4, and /112 for IPv6. Remember to allow ipv6 traffic if you are deploying in a public cloud.
 
+When using IPv6 addresses that are not publicly routed, for example in the ULA range, you might want to add the `--flannel-ipv6-masq` option to enable IPv6 NAT, as per default pods use their pod IPv6 address for outgoing traffic.
+
 If you are using a custom CNI plugin, i.e. a CNI plugin other than Flannel, the additional configuration may be required. Please consult your plugin's dual-stack documentation and verify if network policies can be enabled.
 
 :::warning Known Issue
@@ -180,6 +182,9 @@ Single-stack IPv6 clusters (clusters without IPv4) are supported on K3s using th
 ```bash
 --cluster-cidr=2001:cafe:42::/56 --service-cidr=2001:cafe:43::/112
 ```
+
+When using IPv6 addresses that are not publicly routed, for example in the ULA range, you might want to add the `--flannel-ipv6-masq` option to enable IPv6 NAT, as per default pods use their pod IPv6 address for outgoing traffic.
+
 ## Nodes Without a Hostname
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run K3s with the `--node-name` flag or `K3S_NODE_NAME` environment variable and this will pass the node name to resolve this issue.


### PR DESCRIPTION
I run a cluster in dual stack mode using a cidr from the ULA range following the dual stack docs. Using [these](https://docs.k3s.io/networking/basic-network-options#dual-stack-ipv4--ipv6-networking) instructions, I noticed that pods use their pod IP for (cluster-external) outgoing connections, in this case meaning a ULA address, which obviously does not work. What I intended is that they use the host's address. After some googling, I found the `--flannel-ipv6-masq` option that does what I want. It is documented in the flannel section: https://docs.k3s.io/networking/basic-network-options#flannel-options. However, I think this should also be mentioned in the dual stack and single stack sections, as it is not given that people also read the flannel section.

This PR adds a mention of the need to add `--flannel-ipv6-masq` if using unroutable IPv6 ranges for a cluster.

I'd argue this use case is relatively common. For example, on many cloud platforms you just get a /64 or even a /128, so using something like ULAs is probablly a must.