### PR TITLE
Corrected namespaceSelector for network policy

### DIFF
--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -380,7 +380,7 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            name: kube-system
+            kubernetes.io/metadata.name: kube-system
 ```
 
 With the applied restrictions, DNS will be blocked unless purposely allowed. Below is a network policy that will allow for traffic to exist for DNS.


### PR DESCRIPTION
Corrected namespaceSelector for intra-namespace network policy example. The label "name" does not exist on the namespace resource kube-system, but the label "kubernetes.io/metadata.name" is present.