### PR TITLE
Bump remark-lint-no-dead-urls, readd error on failure

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check internal links
         run: yarn run remark --use remark-validate-links --frail ./docs
       - name: Check external links
-        run: yarn run remark --use remark-lint-no-dead-urls ./docs
+        run: yarn run remark --use remark-lint-no-dead-urls --frail ./docs
       - name: Test build website
         run: yarn build
       

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^18.3.1",
     "remark-cli": "^12.0.1",
     "remark-lint": "^10.0.0",
-    "remark-lint-no-dead-urls": "^2.0.0",
+    "remark-lint-no-dead-urls": "^2.0.1",
     "remark-validate-links": "^13.0.1",
     "remark-validate-links-heading-id": "^0.0.3"
   },
@@ -49,7 +49,19 @@
   "remarkConfig": {
     "plugins": [
       "remark-validate-links-heading-id",
-      "remark-validate-links"
+      "remark-validate-links",
+      [
+        "remark-lint-no-dead-urls",
+        {
+          "skipUrlPatterns": [
+            "^https://www\\.mysql\\.com",
+            "^https://dev\\.mysql\\.com\\.*",
+            "^https://k3d\\.io\\.*",
+            "^https://github\\.com/k3s-io/k3s/blob/master/pkg/daemons/config/types\\.go",
+            "^https://github\\.com/rancher/local-path-provisioner/blob/master/README\\.md"
+          ]
+        }
+      ]
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7829,6 +7829,13 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
+p-all@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-all/-/p-all-5.0.0.tgz#3fcbdf28177a09442fc7f4ec9e252e0eed5ecfc5"
+  integrity sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==
+  dependencies:
+    p-map "^6.0.0"
+
 p-any@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-any/-/p-any-4.0.0.tgz#0e9c8b0fa3e58cc79e6a1c6c715aa9326b6a4447"
@@ -7863,6 +7870,13 @@ p-limit@^4.0.0:
   dependencies:
     yocto-queue "^1.0.0"
 
+p-limit@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.1.0.tgz#d91f9364d3fdff89b0a45c70d04ad4e0df30a0e8"
+  integrity sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==
+  dependencies:
+    yocto-queue "^1.1.1"
+
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
@@ -7890,6 +7904,11 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-map@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-6.0.0.tgz#4d9c40d3171632f86c47601b709f4b4acd70fed4"
+  integrity sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==
 
 p-retry@^4.5.0:
   version "4.6.2"
@@ -8882,15 +8901,17 @@ remark-gfm@^4.0.0:
     remark-stringify "^11.0.0"
     unified "^11.0.0"
 
-remark-lint-no-dead-urls@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/remark-lint-no-dead-urls/-/remark-lint-no-dead-urls-2.0.0.tgz#6d51ca2875086d7e748ca60cdbc2ed9577891ea7"
-  integrity sha512-7kJ5rZ6fuuLt6iG2XS/uShVik0LYzshspZ/hNm/oPybXnJrehsYT31Y5AjeX57Mm7DAc7Q8EMSgeDiK/8SYYhQ==
+remark-lint-no-dead-urls@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-dead-urls/-/remark-lint-no-dead-urls-2.0.1.tgz#608de7331fa8968b63c6bde93f410f31aae2326c"
+  integrity sha512-8+uY2GWENktvnTnmDHsAW/DxuPiAmZiKoW5HGuCrGmlqEVh4jPZJ2IGbQgfpyrMKIwp32NYo7Jt+aKb52QJ6sQ==
   dependencies:
     "@types/mdast" "^4.0.0"
     dead-or-alive "^1.0.0"
     devlop "^1.0.0"
     is-online "^11.0.0"
+    p-all "^5.0.0"
+    p-limit "^6.0.0"
     unified-lint-rule "^3.0.0"
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
@@ -10479,6 +10500,11 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+yocto-queue@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
+  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
remarks-lint-no-dead-urls has been updated to handle "stable" site redirects. We can once again catch errors and fail test deployments. There is still a weird issue around some anchors and certain sites like mysql, so those have been added to an exception list.