### PR TITLE
A server sizing guide for large k3s clusters

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -95,13 +95,17 @@ Additional ports may need to be opened depending on your setup. See [Inbound Rul
 
 Raspberry Pi OS is Debian based, and may suffer from a known iptables bug. See [Known Issues](../known-issues.md#iptables).
 
-Standard Raspberry Pi OS installations do not start with `cgroups` enabled. **K3S** needs `cgroups` to start the systemd service. `cgroups`can be enabled by appending `cgroup_memory=1 cgroup_enable=memory` to `/boot/cmdline.txt`.
+#### Cgroups
+
+Standard Raspberry Pi OS installations do not start with `cgroups` enabled. **K3S** needs `cgroups` to start the systemd service. `cgroups`can be enabled by appending `cgroup_memory=1 cgroup_enable=memory` to `/boot/firmware/cmdline.txt`.\
+**Note:** On Debian 11 and older Pi OS releases the cmdline.txt is located at `/boot/cmdline.txt`.
 
 Example cmdline.txt:
 ```
 console=serial0,115200 console=tty1 root=PARTUUID=58b06195-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_memory=1 cgroup_enable=memory
 ```
 
+#### Ubuntu Vxlan Module
 With Ubuntu 21.10 to Ubuntu 23.10, vxlan support on Raspberry Pi was moved into a separate kernel module. This step in not required for Ubuntu 24.04 and later.
 ```bash
 sudo apt install linux-modules-extra-raspi

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -117,24 +117,42 @@ For more information on which OSs were tested with Rancher managed K3s clusters,
 
 ## Hardware
 
-Hardware requirements scale based on the size of your deployments. Minimum recommendations are outlined here.
+Hardware requirements scale based on the size of your deployments. The minimum requirements are:
 
-|        | Spec | Minimum | Recommended |
-|--------|------|---------|-------------|
-| Server | CPU  | 1 core  | 4 cores     |
-|        | RAM  | 2 GB    | 4 GB        |
-| Agent  | CPU  | 1 core  | 2 cores     |
-|        | RAM  | 512 MB  | 1 GB        |
+|  Node  |   CPU   |  RAM   |
+|--------|---------|--------|
+| Server | 2 cores | 2 GB   |
+| Agent  | 1 core  | 512 MB |
 
-[Resource Profiling](../reference/resource-profiling.md) captures the results of tests to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent. It also contains analysis about what has the biggest impact on K3s server and agent utilization, and how the cluster datastore can be protected from interference from agents and workloads.
+[Resource Profiling](../reference/resource-profiling.md) captures the results of tests and analysis to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent.
 
-:::info Raspberry Pi and embedded etcd
-If deploying K3s with embedded etcd on a Raspberry Pi, it is recommended that you use an external SSD. etcd is write intensive, and SD cards cannot handle the IO load.
+### Disks
+
+K3s performance depends on the performance of the database. To ensure optimal speed, we recommend using an SSD when possible. 
+
+If deploying K3s on a Raspberry Pi or other ARM devices, it is recommended that you use an external SSD. etcd is write intensive; SD cards and eMMC cannot handle the IO load.
+
+### Server Sizing Guide
+
+When limited on CPU and RAM on the server (control-plane + etcd) node, there are limitations on the amount of agent nodes that can be joined under standard workload conditions.
+
+| Server CPU | Server RAM | Number of Agents |
+| ---------- | ---------- | ---------------- |
+| 2          | 4 GB       | 0-350            |
+| 4          | 8 GB       | 351-900          |
+| 8          | 16 GB      | 901-1800         |
+| 16+        | 32 GB      | 1800+            |
+
+:::tip High Availability Sizing
+When using a high-availability setup of 3 server nodes, the number of agents can scale roughly ~50% more than the above table. \
+Ex: 3 server with 4 vCPU/8 GB can scale to ~1200 agents.
 :::
 
-#### Disks
+It is recommended to join agent nodes in batches of 50 or less to allow the CPU to free up space, as there is a spike on node join. Remember to modify the default `cluster-cidr` if desiring more than 255 nodes!
 
-K3s performance depends on the performance of the database. To ensure optimal speed, we recommend using an SSD when possible. Disk performance will vary on ARM devices utilizing an SD card or eMMC.
+[Resource Profiling](../reference/resource-profiling.md#server-sizing-requirements-for-k3s) contains more information how these recommendations were found.
+
+
 
 ## Networking
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -115,10 +115,12 @@ For more information on which OSs were tested with Rancher managed K3s clusters,
 
 Hardware requirements scale based on the size of your deployments. Minimum recommendations are outlined here.
 
-| Spec | Minimum | Recommended |
-|------|---------|-------------|
-| CPU  | 1 core      | 2 cores          |
-| RAM  | 512 MB  | 1 GB        |
+|        | Spec | Minimum | Recommended |
+|--------|------|---------|-------------|
+| Server | CPU  | 1 core  | 4 cores     |
+|        | RAM  | 2 GB    | 4 GB        |
+| Agent  | CPU  | 1 core  | 2 cores     |
+|        | RAM  | 512 MB  | 1 GB        |
 
 [Resource Profiling](../reference/resource-profiling.md) captures the results of tests to determine minimum resource requirements for the K3s agent, the K3s server with a workload, and the K3s server with one agent. It also contains analysis about what has the biggest impact on K3s server and agent utilization, and how the cluster datastore can be protected from interference from agents and workloads.
 


### PR DESCRIPTION
- Fix minimum spec table to differentiate between server and agent specs
- Fix cgroups for newer Pi OS versions.