### PR TITLE
Remove untranslated zh footer file

### DIFF
--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -1,6 +1,0 @@
-{
-  "copyright": {
-    "message": "Copyright © 2022 K3s Project Authors. All rights reserved. <br>The Linux Foundation has registered trademarks\n      and uses trademarks. For a list of trademarks of The Linux Foundation, \n      please see our <a href=\"https://www.linuxfoundation.org/trademark-usage\"> Trademark Usage</a> page.",
-    "description": "The footer copyright"
-  }
-}


### PR DESCRIPTION
The file has not been translated so it's not necessary (and the copyright year is outdated). 