### PR TITLE
Hide old cis and remove 1.20 information

### DIFF
--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -405,11 +405,7 @@ spec:
   - Ingress
 ```
 
-The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Traefik v1 as packaged in K3s version 1.20 and below uses different labels than Traefik v2. Ensure that you only use the sample yaml below that is associated with the version of Traefik present on your cluster.
-
-<Tabs>
-<TabItem value="v1.21 and Newer" default>
-
+The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Ensure that you use the sample yaml below:
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -452,60 +448,7 @@ spec:
   - {}
   policyTypes:
   - Ingress
----
-
 ```
-</TabItem>
-
-<TabItem value="v1.20 and Older" default>
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-metrics-server
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      k8s-app: metrics-server
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-svclbtraefik-ingress
-  namespace: kube-system
-spec:
-  podSelector: 
-    matchLabels:
-      svccontroller.k3s.cattle.io/svcname: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-traefik-v120-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      app: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-
-```
-</TabItem>
-</Tabs>
 
 :::info
 Operators must manage network policies as normal for additional namespaces that are created.

--- a/sidebars.js
+++ b/sidebars.js
@@ -47,7 +47,6 @@ module.exports = {
         'security/hardening-guide',
         'security/self-assessment-1.8',
         'security/self-assessment-1.7',
-        'security/self-assessment-1.24',
       ],
     },
     {


### PR DESCRIPTION
This PR hides the old cis1-24 and removes information related to traefikv1 and kubernetes 1.20 and older