### PR TITLE
Seperate Browserslist DB update into monthly CI

### DIFF
--- a/.github/workflows/browserlist.yml
+++ b/.github/workflows/browserlist.yml
@@ -1,0 +1,28 @@
+name: Update Browserslist
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 3 * *' # Every 3rd day of Month at 6:00 AM
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  browserlist:
+    if: github.repository == 'k3s-io/docs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Update Browserlist
+        run: npx update-browserslist-db@latest
+      - name: Get current month and year
+        id: date
+        run: echo "month_year=$(date +'%B %Y')" >> $GITHUB_OUTPUT
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: update release-notes/k3s-*.md
+          title: Update Browsers List DB ${{ steps.date.outputs.month_year }}
+          body: Automated npx update-browserslist-db@latest
+          branch: update-browserslist-db
+          signoff: true

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,8 +32,6 @@ jobs:
           pip install codespell
       - name: Run codespell
         run: codespell
-      - name: Update Browserlist
-        run: npx update-browserslist-db@latest
       - name: Get current month and year
         id: date
         run: echo "month_year=$(date +'%B %Y')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It's confusing when its run inside the Release Notes automated CI. Instead run it as a monthly cron job.