### PR TITLE
basic-network-options: use v6 example ranges

### DIFF
--- a/docs/networking/basic-network-options.md
+++ b/docs/networking/basic-network-options.md
@@ -164,7 +164,7 @@ Dual-stack networking must be configured when the cluster is first created. It c
 To enable dual-stack in K3s, you must provide valid dual-stack `cluster-cidr` and `service-cidr` on all server nodes. This is an example of a valid configuration:
 
 ```
---cluster-cidr=10.42.0.0/16,2001:cafe:42::/56 --service-cidr=10.43.0.0/16,2001:cafe:43::/112
+--cluster-cidr=10.42.0.0/16,2001:db8:42::/56 --service-cidr=10.43.0.0/16,2001:db8:43::/112
 ```
 
 Note that you may configure any valid `cluster-cidr` and `service-cidr` values, but the above masks are recommended. If you change the `cluster-cidr` mask, you should also change the `node-cidr-mask-size-ipv4` and `node-cidr-mask-size-ipv6` values to match the planned pods per node and total node count. The largest supported `service-cidr` mask is /12 for IPv4, and /112 for IPv6. Remember to allow ipv6 traffic if you are deploying in a public cloud.
@@ -190,7 +190,7 @@ If your IPv6 default route is set by a router advertisement (RA), you will need 
 Single-stack IPv6 clusters (clusters without IPv4) are supported on K3s using the `--cluster-cidr` and `--service-cidr` flags. This is an example of a valid configuration:
 
 ```bash
---cluster-cidr=2001:cafe:42::/56 --service-cidr=2001:cafe:43::/112
+--cluster-cidr=2001:db8:42::/56 --service-cidr=2001:db8:43::/112
 ```
 
 When using IPv6 addresses that are not publicly routed, for example in the ULA range, you might want to add the `--flannel-ipv6-masq` option to enable IPv6 NAT, as per default pods use their pod IPv6 address for outgoing traffic.


### PR DESCRIPTION
2001:db8::/32 is the reserved documentation range, which should be used instead of a range that might be assigned to someone. See https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6 for details.

We can't fix the v4 addresses since there are only some documentation /24s and nothing larger.