### PR TITLE
Add s3 retention flag to the docs

### DIFF
--- a/docs/cli/etcd-snapshot.md
+++ b/docs/cli/etcd-snapshot.md
@@ -122,6 +122,16 @@ $ k3s etcd-snapshot --s3 --s3-bucket=test-bucket --s3-access-key=test --s3-secre
 Name                              Location                                                                          Size    Created
 ```
 
+### S3 Retention
+
+:::info Version Gate
+Starting in versions v1.34.0+k3s1, v1.33.4+k3s1, v1.32.8+k3s1, v1.31.12+k3s1, K3s includes a new flag for S3 retention. It has the same default value as the local snapshot retention.
+:::
+
+| Flag | Description |
+| ----------- | --------------- |
+| `--etcd-s3-retention` | Number of snapshots in S3 to retain (default: `5`) |
+
 
 ### S3 Configuration Secret Support
 


### PR DESCRIPTION
- OBS: it will be merged only after the august release, so it will sit here in the mean time.

Decided to create a new sub part in s3 docs, since it have a version gate and for easy access.