### PR TITLE
fix(docs): update image references to use docker.io

### DIFF
--- a/docs/upgrades/automated.md
+++ b/docs/upgrades/automated.md
@@ -69,7 +69,7 @@ spec:
       - "true"
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade
+    image: docker.io/rancher/k3s-upgrade
   channel: https://update.k3s.io/v1-release/channels/stable
 ---
 # Agent plan
@@ -89,10 +89,10 @@ spec:
     args:
     - prepare
     - server-plan
-    image: rancher/k3s-upgrade
+    image: docker.io/rancher/k3s-upgrade
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade
+    image: docker.io/rancher/k3s-upgrade
   channel: https://update.k3s.io/v1-release/channels/stable
 ```
 


### PR DESCRIPTION
since k8s v1.34 must include register in images, it's best to include that in the documentation and be prepared for the upgrade.