### PR TITLE
Add Gateway API information

### DIFF
--- a/docs/networking/networking-services.md
+++ b/docs/networking/networking-services.md
@@ -33,10 +33,37 @@ To remove Traefik from your cluster, start all servers with the `--disable=traef
 For more information, see [Managing Packaged Components](../installation/packaged-components.md).
 
 For details on the specific version of Traefik included with K3s, consult the Release Notes for your version.
-* K3s versions starting with **1.32** include Traefik v3. Existing installations of Traefik v2 will be automatically upgraded to v3 when K3s is upgraded.
-  Traefik v3 should be compatible with configuration from v2; consult the upstream [v2 to v3 migration](https://doc.traefik.io/traefik/migrate/v2-to-v3/) docs for more information.
-* K3s versions **1.21** through **1.31** included Traefik v2, unless an existing installation of Traefik v1 was found, in which case Traefik was not upgraded to v2.
-* K3s versions **1.20** and **earlier** included Traefik v1.
+
+### Gateway API
+
+Gateway API is a family of Kubernetes resources that provide dynamic infrastructure provisioning and advanced traffic routing. While the traditional Ingress API is still supported (and not planned to be deprecated), the Gateway API provides a more expressive, role-oriented, and extensible way to manage service exposure.
+
+K3s comes with Traefik v3, which includes optional support for the Gateway API. In order to enable Gateway API support, deploy a HelmChartConfig that sets `providers.kubernetesGateway.enabled` to true. For example:
+
+```yaml
+# /var/lib/rancher/k3s/server/manifests/k3s-traefik-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    providers:
+      kubernetesGateway:
+        enabled: true
+#       experimentalChannel: true (read warning below)
+```
+Traefik is compatible with [Gateway API v1.4](https://gateway-api.sigs.k8s.io/reference/1.4/spec/).
+
+:::warning Gateway API resources
+Prior to the April 2026 releases (v1.33.11+k3s1, v1.34.7+k3s1 and v1.35.4+k3s1) Gateway API CRDs are removed if traefik is disabled after previously having been enabled. When using an affected release, avoid disabling traefik or uninstalling the traefik-crds AddOn if your cluster contains Gateway API resources that you do not want removed.
+:::
+
+:::warning
+If you need support for experimental Gateway API resources, e.g. TCPRoute, you must install the [v1.4 experimental-install.yaml](https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml) from the official [gateway-api releases](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.0) and use the option `providers.kubernetesGateway.experimentalChannel=true` in the k3s-traefik chart values.
+:::
 
 ## Network Policy Controller
 


### PR DESCRIPTION
This PR adds Gateway API information and removes the old information about Traefic v2 now that 1.32 (and older) are EOL