### PR TITLE
remove outdated control plane CPU/memory table

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -226,17 +226,7 @@ Hardware requirements are based on the size of your K3s cluster. For production 
 - PostgreSQL
 - etcd
 
-### CPU and Memory
-
-The following are the minimum CPU and memory requirements for nodes in a high-availability K3s server:
-
-| Deployment Size |   Nodes   | vCPUs |  RAM  |
-|:---------------:|:---------:|:-----:|:-----:|
-|      Small      |  Up to 10 |   2   |  4 GB |
-|      Medium     | Up to 100 |   4   |  8 GB |
-|      Large      | Up to 250 |   8   | 16 GB |
-|     X-Large     | Up to 500 |   16  | 32 GB |
-|     XX-Large    |   500+    |   32  | 64 GB |
+For control-plane node CPU and memory sizing relative to the number of agents, see the [Server Sizing Guide](#server-sizing-guide) above.
 
 ### Disks
 


### PR DESCRIPTION
### Proposed Changes

The `## Large Clusters` → `### CPU and Memory` table in
`docs/installation/requirements.md` was contradictory with the
`### Server Sizing Guide` higher in the same page: the Server Sizing Guide
says 2 CPU / 4 GB control planes support up to 350 agents, while the
"CPU and Memory" table claimed the same 2 CPU / 4 GB was only good for up to
10 total nodes.

Per the maintainer's comment on the linked issue, the Large Clusters CPU/Memory
table is outdated and the Server Sizing Guide is the authoritative source. This
PR removes the outdated table and replaces it with a one-line pointer up to the
Server Sizing Guide, leaving the rest of the Large Clusters section (HA / external
database, Disks, Network, Database sizing) untouched.

### Linked Issues

Addresses issue [k3s-io/docs#417](https://github.com/k3s-io/docs/issues/417).

### Further Comments

AI assistance disclosure: I used Claude Code (an AI tool) to help locate the
relevant content and draft this change. I reviewed every line and the resulting
diff is intentionally minimal — one outdated subsection removed, one cross-reference
sentence added — matching the maintainer's guidance on the issue.
