### PR TITLE
Drop EOL Version Gates

### DIFF
--- a/docs/cli/etcd-snapshot.md
+++ b/docs/cli/etcd-snapshot.md
@@ -106,6 +106,11 @@ K3s supports replicating etcd snapshots to and restoring etcd snapshots from S3-
 | `--etcd-s3-timeout` | S3 timeout (default: `5m0s`) |
 | `--etcd-s3-config-secret` | Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set |
 
+:::note
+`--etcd-snapshot-retention` sets `--etcd-s3-retention`, if it is not explicitly set in the config.
+:::
+
+
 For example, this is how the creation and deletion of on-demand etcd snapshots in S3 would work:
 
 ```shell-session
@@ -125,22 +130,7 @@ $ k3s etcd-snapshot --s3 --s3-bucket=test-bucket --s3-access-key=test --s3-secre
 Name                              Location                                                                          Size    Created
 ```
 
-### S3 Retention
-
-:::info Version Gate
-Starting in versions v1.34.0+k3s1, v1.33.4+k3s1, v1.32.8+k3s1, v1.31.12+k3s1, K3s includes a new flag for S3 retention. It has the same default value as the local snapshot retention.
-:::
-
-| Flag | Description |
-| ----------- | --------------- |
-| `--etcd-s3-retention` | Number of snapshots in S3 to retain (default: `5`) |
-
-
 ### S3 Configuration Secret Support
-
-:::info Version Gate
-S3 Configuration Secret support is available as of the August 2024 releases: v1.30.4+k3s1, v1.29.8+k3s1, v1.28.13+k3s1
-:::
 
 K3s supports reading etcd S3 snapshot configuration from a Kubernetes Secret.
 This may be preferred to hardcoding credentials in K3s CLI flags or config files for security reasons, or if credentials need to be rotated without restarting K3s.

--- a/docs/cli/secrets-encrypt.md
+++ b/docs/cli/secrets-encrypt.md
@@ -21,10 +21,6 @@ Failure to follow proper procedure for rotating encryption keys can leave your c
 
 ### Encryption Key Rotation
 
-:::info Version Gate
-Available as of the September 2024 releases: v1.30.5+k3s1, v1.31.1+k3s1
-:::
-
 <Tabs groupId="se" queryString>
 <TabItem value="Single-Server" default>
 To rotate secrets encryption keys on a single-server cluster:

--- a/docs/datastore/ha-embedded.md
+++ b/docs/datastore/ha-embedded.md
@@ -63,10 +63,6 @@ There are a few config flags that must be the same in all server nodes:
 
 ## Existing single-node clusters
 
-:::info Version Gate
-Available as of [v1.22.2+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.22.2%2Bk3s1)
-:::
-
 If you have an existing cluster using the default embedded SQLite database, you can convert it to etcd by simply restarting your K3s server with the `--cluster-init` flag. Once you've done that, you'll be able to add additional instances as described above.
 
 If an etcd datastore is found on disk either because that node has either initialized or joined a cluster already, the datastore arguments (`--cluster-init`, `--server`, `--datastore-endpoint`, etc) are ignored.

--- a/docs/installation/private-registry.md
+++ b/docs/installation/private-registry.md
@@ -23,10 +23,6 @@ For example, when pulling `registry.example.com:5000/rancher/mirrored-pause:3.6`
 In order to be recognized as a registry, the first component of the image name must contain at least one period or colon.
 For historical reasons, images without a registry specified in their name are implicitly identified as being from `docker.io`.
 
-:::info Version Gate
-The `--disable-default-registry-endpoint` option is available as of January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1
-:::
-
 Nodes may be started with the `--disable-default-registry-endpoint` option.
 When this is set, containerd will not fall back to the default registry endpoint, and will only pull from configured mirror endpoints,
 along with the distributed registry if it is enabled.
@@ -105,11 +101,6 @@ mirrors:
       "^rancher/(.*)": "mirrorproject/rancher-images/$1"
 ```
 
-:::info Version Gate
-Rewrites are no longer applied to the [Default Endpoint](#default-endpoint-fallback) as of the January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1  
-Prior to these releases, rewrites were also applied to the default endpoint, which would prevent K3s from pulling from the upstream registry if the image could not be pulled from a mirror endpoint, and the image was not available under the modified name in the upstream.
-::::
-
 If you want to apply rewrites when pulling directly from a registry - when it is not being used as a mirror for a different upstream registry - you must provide a mirror endpoint that does not match the default endpoint.
 Mirror endpoints in `registries.yaml` that match the default endpoint are ignored; the default endpoint is always tried last with no rewrites, if fallback has not been disabled.
 
@@ -153,10 +144,6 @@ The `auth` part consists of either username/password or authentication token:
 Below are basic examples of using private registries in different modes:
 
 ### Wildcard Support
-
-:::info Version Gate
-Wildcard support is available as of the March 2024 releases: v1.26.15+k3s1, v1.27.12+k3s1, v1.28.8+k3s1, v1.29.3+k3s1
-:::
 
 The `"*"` wildcard entry can be used in the `mirrors` and `configs` sections to provide default configuration for all registries.
 The default configuration will only be used if there is no specific entry for that registry. Note that the asterisk MUST be quoted.

--- a/docs/installation/registry-mirror.md
+++ b/docs/installation/registry-mirror.md
@@ -2,10 +2,6 @@
 title: Embedded Registry Mirror
 ---
 
-:::info Version Gate
-The Embedded Registry Mirror is available as an experimental feature as of January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1 and GA as of December 2024 releases: v1.29.12+k3s1, v1.30.8+k3s1, v1.31.4+k3s1
-:::
-
 K3s embeds [Spegel](https://github.com/spegel-org/spegel), a stateless distributed OCI registry mirror that allows peer-to-peer sharing of container images between nodes in a Kubernetes cluster. The distributed registry mirror is disabled by default. For K3s to leverage it, you must enable both the [Distributed OCI Registry Mirror](#enabling-the-distributed-oci-registry-mirror) and the [Registry mirroring](#enabling-registry-mirroring) as explained in the following subsections.
 
 ## Enabling The Distributed OCI Registry Mirror
@@ -56,10 +52,6 @@ registries are enabled - by listing it in the mirrors section:
 mirrors:
   mirror.example.com:
 ```
-
-:::info Version Gate
-Wildcard support is available as of the March 2024 releases: v1.26.15+k3s1, v1.27.12+k3s1, v1.28.8+k3s1, v1.29.3+k3s1
-:::
 
 The `"*"` wildcard mirror entry can be used to enable distributed mirroring of all registries. Note that the asterisk MUST be quoted:
 ```yaml

--- a/docs/networking/basic-network-options.md
+++ b/docs/networking/basic-network-options.md
@@ -26,23 +26,6 @@ This page describes K3s network configuration options, including configuration o
 | `--flannel-backend=ipsec` | Use strongSwan IPSec via the `swanctl` binary to encrypt network traffic. (Deprecated; will be removed in v1.27.0) |
 | `--flannel-backend=none` | Disable Flannel entirely. |
 
-:::info Version Gate
-
-K3s no longer includes strongSwan `swanctl` and `charon` binaries starting with the 2022-12 releases (v1.26.0+k3s1, v1.25.5+k3s1, v1.24.9+k3s1, v1.23.15+k3s1). Please install the correct packages on your node before upgrading to or installing these releases if you want to use the `ipsec` backend.
-
-:::
-
-### Migrating from `wireguard` or `ipsec` to `wireguard-native`
-
-The legacy `wireguard` backend requires installation of the `wg` tool on the host. This backend is not available in K3s v1.26 and higher, in favor of `wireguard-native` backend, which directly interfaces with the kernel.
-
-The legacy `ipsec` backend requires installation of the `swanctl` and `charon` binaries on the host. This backend is not available in K3s v1.27 and higher, in favor of the `wireguard-native` backend.
-
-We recommend that users migrate to the new backend as soon as possible. The migration requires a short period of downtime while nodes come up with the new configuration. You should follow these two steps:
-
-1. Update the K3s config on all server nodes. If using config files, the `/etc/rancher/k3s/config.yaml` should include `flannel-backend: wireguard-native` instead of `flannel-backend: wireguard` or `flannel-backend: ipsec`. If you are configuring K3s via CLI flags in the systemd unit, the equivalent flags should be changed.
-2. Reboot all nodes, starting with the servers.
-
 ### Flannel Agent Options
 
 * These options are available for each agent and are specific to the Flannel instance running on that node
@@ -140,17 +123,6 @@ The egress selector mode may be configured on servers via the `--egress-selector
 
 ## Dual-stack (IPv4 + IPv6) Networking
 
-:::info Version Gate
-
-Experimental support is available as of [v1.21.0+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.21.0%2Bk3s1).  
-Stable support is available as of [v1.23.7+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.23.7%2Bk3s1). 
-
-:::
-
-:::warning Known Issue 
-
-Before 1.27, Kubernetes [Issue #111695](https://github.com/kubernetes/kubernetes/issues/111695) causes the Kubelet to ignore the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, use 1.27 or newer or add the following flag to both K3s servers and agents:
-
 ```
 --kubelet-arg="node-ip=0.0.0.0" # To proritize IPv4 traffic
 #OR
@@ -179,10 +151,6 @@ When defining cluster-cidr and service-cidr with IPv6 as the primary family, the
 :::
 
 ## Single-stack IPv6 Networking
-
-:::info Version Gate
-Available as of [v1.22.9+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.22.9%2Bk3s1)
-:::
 
 :::warning Known Issue
 If your IPv6 default route is set by a router advertisement (RA), you will need to set the sysctl `net.ipv6.conf.all.accept_ra=2`; otherwise, the node will drop the default route once it expires. Be aware that accepting RAs could increase the risk of [man-in-the-middle attacks](https://github.com/kubernetes/kubernetes/issues/91507).

--- a/docs/networking/multus-ipams.md
+++ b/docs/networking/multus-ipams.md
@@ -8,10 +8,6 @@ For more information about Multus, refer to the [multus-cni](https://github.com/
 
 Multus can not be deployed standalone. It always requires at least one conventional CNI plugin that fulfills the Kubernetes cluster network requirements. That CNI plugin becomes the default for Multus, and will be used to provide the primary interface for all pods. When deploying K3s with default options, that CNI plugin is Flannel.
 
-:::info Version Gate
-K3s uses a fixed CNI binary path as of the October 2024 releases: v1.28.15+k3s1, v1.29.10+k3s1, v1.30.6+k3s1, v1.31.2+k3s1.
-:::
-
 K3s looks at `$DATA_DIR/data/cni` for CNI plugin binaries. By default this is `/var/lib/rancher/k3s/data/cni`. Additional CNI plugins should be installed to this location.
 
 Prior to the October 2024 releases, CNI binaries were part of the K3s userspace bundle at `$DATA_DIR/data/$HASH/bin`, where the hash is unique to each release of K3s.

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -42,10 +42,6 @@ Setting `K3S_URL` without explicitly setting an exec command will default the co
 
 When running the agent, `K3S_TOKEN` must also be set.
 
-:::info Version Gate
-Available as of October 2024 releases: v1.28.15+k3s1, v1.29.10+k3s1, v1.30.6+k3s1, v1.31.2+k3s1.
-:::
-
 K3s will now use `PATH` to find alternative container runtimes, in addition to checking the default paths used by the container runtime packages. In order to use this feature, you must modify the K3s service's PATH environment variable to add the directories containing the container runtime binaries.
 
 It's recommended that you modify one of this two environment files:


### PR DESCRIPTION
There are a few Version Gates which are pointing at releases that are all EOLed. This PR removes them